### PR TITLE
Fix thread-safety of logging that leads to unpredictable freezes of the GUI

### DIFF
--- a/src/org/myrobotlab/control/widget/Console.java
+++ b/src/org/myrobotlab/control/widget/Console.java
@@ -214,9 +214,17 @@ public class Console extends AppenderSkeleton implements Appender<ILoggingEvent>
 	public void doAppend(ILoggingEvent loggingEvent) throws LogbackException {
 		//append(loggingEvent);
 		if (logging) {
-			String msg = String.format("[%s] %s", loggingEvent.getThreadName(), loggingEvent.toString()).trim();
-			textArea.append(msg + "\n");
+			final String msg = String.format("[%s] %s", loggingEvent.getThreadName(), loggingEvent.toString()).trim();
+
+			// textarea not threadsafe, needs invokelater
+			EventQueue.invokeLater(new Runnable() {
+		            //@Override
+		            public void run() {  	
+		            	textArea.append(msg + "\n");
+		            }
+			});
 		}
 		
 	}
+	
 }

--- a/src/org/myrobotlab/control/widget/Console.java
+++ b/src/org/myrobotlab/control/widget/Console.java
@@ -1,6 +1,7 @@
 package org.myrobotlab.control.widget;
 
 import java.awt.Component;
+import java.awt.EventQueue;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/org/myrobotlab/control/widget/Console.java
+++ b/src/org/myrobotlab/control/widget/Console.java
@@ -54,11 +54,14 @@ public class Console extends AppenderSkeleton implements Appender<ILoggingEvent>
 		if (logging) {
 			final String message = this.layout.format(loggingEvent);
 
-			// Append formatted message to textarea using the Swing Thread.
-			// SwingUtilities.invokeLater(new Runnable() { WOW, this was a nasty
-			// bug !
-			// public void run() {
-			textArea.append(message);
+			// textarea not threadsafe, needs invokelater
+			EventQueue.invokeLater(new Runnable() {
+		            //@Override
+		            public void run() {  	
+		            	textArea.append(message + "\n");
+		            }
+			});
+
 			/*
 			 * if (textArea.getText().length() > maxBuffer) {
 			 * textArea.replaceRange("", 0, maxBuffer/10); // erase tenth }
@@ -68,8 +71,16 @@ public class Console extends AppenderSkeleton implements Appender<ILoggingEvent>
 		}
 	}
 
-	public void append(String msg) {
-		textArea.append(msg);
+	public void append(final String msg) {
+
+		// textarea not threadsafe, needs invokelater
+		EventQueue.invokeLater(new Runnable() {
+	            //@Override
+	            public void run() {  	
+	            	textArea.append(msg + "\n");
+	            }
+		});
+
 	}
 
 	@Override


### PR DESCRIPTION
textArea.append is not threadsafe, which made the GUI freeze. Using invokeLater is the documented way to handle the EventQueue when multithreading.