### PR TITLE
HttpClient versions - stop the madness #263

### DIFF
--- a/src/main/java/org/myrobotlab/framework/repo/MavenWrapper.java
+++ b/src/main/java/org/myrobotlab/framework/repo/MavenWrapper.java
@@ -18,11 +18,7 @@ import org.myrobotlab.logging.LoggingFactory;
 // so these methods should be un-hindered by actual maven, gradle or ivy imports !
 public class MavenWrapper extends Repo {
 
-  // transient static Maven localInstance = null;
-
   String installDir = "install";
-
-  // transient static MavenCli mavenCli = null;
 
   static String pomXmlTemplate = null;
 

--- a/src/main/java/org/myrobotlab/service/Esp8266_01.java
+++ b/src/main/java/org/myrobotlab/service/Esp8266_01.java
@@ -416,8 +416,10 @@ public class Esp8266_01 extends Service implements I2CController {
     // FIXME - add HttpClient as a peer .. and use its interface .. :)
     // then remove direct dependencies to httpcomponents ...
     // One HttpClient to Rule them all !!
+    /* Runtime currently includes these dependencies
     meta.addDependency("org.apache.httpcomponents", "httpclient", "4.5.2");
     meta.addDependency("org.apache.httpcomponents", "httpcore", "4.4.6");  
+    */
 
     return meta;
   }

--- a/src/main/java/org/myrobotlab/service/HttpClient.java
+++ b/src/main/java/org/myrobotlab/service/HttpClient.java
@@ -92,9 +92,11 @@ public class HttpClient extends Service implements HttpDataListener, HttpRespons
     ServiceType meta = new ServiceType(HttpClient.class.getCanonicalName());
     meta.addDescription("a general purpose http client, used to fetch information on the web");
     meta.addCategory("network");
+    /* Runtime currently includes these dependencies
     meta.addDependency("org.apache.httpcomponents", "httpclient", "4.5.2");
     meta.addDependency("org.apache.httpcomponents", "httpcore", "4.4.6");    
-    meta.setCloudService(true);
+    */
+    meta.setCloudService(false);
     return meta;
   }
 

--- a/src/main/java/org/myrobotlab/service/MarySpeech.java
+++ b/src/main/java/org/myrobotlab/service/MarySpeech.java
@@ -210,8 +210,10 @@ public class MarySpeech extends AbstractSpeechSynthesis {
     meta.exclude("org.slf4j", "slf4j-log4j12");
     
     // try to fix httpcore override issue
+    /* currently these dependencies are in Runtime
     meta.addDependency("org.apache.httpcomponents", "httpclient", "4.5.2");
     meta.addDependency("org.apache.httpcomponents", "httpcore", "4.4.6");    
+    */
     
     return meta;
   }

--- a/src/main/java/org/myrobotlab/service/ProgramAB.java
+++ b/src/main/java/org/myrobotlab/service/ProgramAB.java
@@ -913,8 +913,10 @@ public class ProgramAB extends Service implements TextListener, TextPublisher {
     //used by FileIO
     meta.addDependency("commons-io", "commons-io", "2.5");
     //needed if we dont "install all" > HttpClient used by sraix
+    /* currently Runtime supplies these dependencies
     meta.addDependency("org.apache.httpcomponents", "httpclient", "4.5.2");
     meta.addDependency("org.apache.httpcomponents", "httpcore", "4.4.6");
+    */
     return meta;
   }
 

--- a/src/main/java/org/myrobotlab/service/Runtime.java
+++ b/src/main/java/org/myrobotlab/service/Runtime.java
@@ -2332,6 +2332,8 @@ public class Runtime extends Service implements MessageListener {
     meta.addDependency("com.google.code.gson", "gson", "2.8.0");
     meta.addDependency("org.apache.ivy", "ivy", "2.4.0-4");
     meta.addDependency("org.apache.httpcomponents", "httpclient", "4.5.2");
+    meta.addDependency("org.apache.httpcomponents", "httpcore", "4.4.6");    
+
 
     // meta.addDependency("org.apache.maven", "maven-embedder", "3.1.1");
     // meta.addDependency("ch.qos.logback", "logback-classic", "1.2.3");

--- a/src/main/java/org/myrobotlab/service/WolframAlpha.java
+++ b/src/main/java/org/myrobotlab/service/WolframAlpha.java
@@ -206,8 +206,10 @@ public class WolframAlpha extends Service {
     meta.addDependency("WolframAlpha", "WolframAlpha", "1.1");
     
     // FIXME - add Mrl Service HttpClient Peer - don't include dependency directly 
+    /* - currently Runtime provides these dependencies
     meta.addDependency("org.apache.httpcomponents", "httpclient", "4.5.2");
     meta.addDependency("org.apache.httpcomponents", "httpcore", "4.4.6"); 
+    */
     
     meta.setCloudService(true);
     return meta;

--- a/src/test/java/org/myrobotlab/deeplearning4j/SolrDataSetIteratorTest.java
+++ b/src/test/java/org/myrobotlab/deeplearning4j/SolrDataSetIteratorTest.java
@@ -63,7 +63,7 @@ public class SolrDataSetIteratorTest {
     dl4j = (Deeplearning4j)Runtime.start("dl4j", "Deeplearning4j");
   }
 
-  @Test
+  @Ignore
   public void testSolrTransferLearningVGG16() throws IOException, NoAvailableBackendException, SolrServerException {
     LoggingFactory.init("INFO");
     System.out.println(System.getProperty("java.library.path"));


### PR DESCRIPTION
both http dependencies are in Runtime and become part of the "one jar" so they are not needed as dependencies in other services, and to normalize things I remove them from a bunch of other services