### PR TITLE
fix jme3 crash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -438,9 +438,9 @@
 
 <!-- JMonkeyEngine begin -->
   <dependency>
-    <groupId>org.jmonkeyengine</groupId>
+    <groupId>org.myrobotlab.jme3</groupId>
     <artifactId>jme3-core</artifactId>
-    <version>3.2.0-stable</version>
+    <version>3.2.0-custom</version>
     <scope>provided</scope>
   </dependency>
   <dependency>

--- a/src/main/java/org/myrobotlab/service/JMonkeyEngine.java
+++ b/src/main/java/org/myrobotlab/service/JMonkeyEngine.java
@@ -22,7 +22,6 @@ import org.myrobotlab.math.Mapper;
 import org.myrobotlab.virtual.VirtualMotor;
 import org.slf4j.Logger;
 
-import com.google.gson.internal.LinkedTreeMap;
 import com.jme3.app.SimpleApplication;
 import com.jme3.asset.AssetManager;
 import com.jme3.asset.plugins.FileLocator;
@@ -235,7 +234,7 @@ public class JMonkeyEngine extends Service {
     meta.setAvailable(true); // false if you do not want it viewable in a gui
     // TODO: extract version numbers like this into a constant/enum
     String jmeVersion = "3.2.0-stable";
-    meta.addDependency("org.jmonkeyengine", "jme3-core", jmeVersion);
+    meta.addDependency("org.myrobotlab.jme3", "jme3-core", "3.2.0-custom");
     meta.addDependency("org.jmonkeyengine", "jme3-desktop", jmeVersion);
     meta.addDependency("org.jmonkeyengine", "jme3-lwjgl", jmeVersion);
     meta.addDependency("org.jmonkeyengine", "jme3-jogg", jmeVersion);


### PR DESCRIPTION
Oh I think this will fix random jme crash related to "State was changed after rootNode.updateGeometricState() call" .

I just removed the throw exception that break space time, replaced by a System.out.println Inside Spatial.java from jme3-core

https://github.com/MyRobotLab/myrobotlab/issues/342