### PR TITLE
fixing dependencies to support leap motion on 64 bit.  

### DIFF
--- a/src/main/java/org/myrobotlab/service/LeapMotion.java
+++ b/src/main/java/org/myrobotlab/service/LeapMotion.java
@@ -210,6 +210,16 @@ public class LeapMotion extends Service implements LeapDataListener, LeapDataPub
     meta.addDescription("Leap Motion Service");
     meta.addCategory("sensor", "telerobotics");
     meta.addDependency("leapmotion", "leap", "2.1.3");
+
+    // TODO: These will overwrite each other!  we need to be selective for the platform of what we deploy.
+    // I believe the 32bit libraries would overwrite the 64bit libraries. 
+    // meta.addDependency("leapmotion", "leap-linux32", "2.1.3", "zip");
+    // meta.addDependency("leapmotion", "leap-win32", "2.1.3", "zip");
+    // 64 bit support only for now.  until we can switch out dependencies based on the current platform.
+    meta.addDependency("leapmotion", "leap-win64", "2.1.3", "zip");
+    meta.addDependency("leapmotion", "leap-mac64", "2.1.3", "zip");
+    meta.addDependency("leapmotion", "leap-linux64", "2.1.3", "zip");
+    
     return meta;
   }
 


### PR DESCRIPTION
I've deployed the natives to the mrl repo.  unfortuantely, if you unzip both win64 and win32 into mrl directory, the file names will collide.  So I'm only adding 64 bit support for now.  If someone wants/needs 32 bit support they can unzip the approriate natives into the libraries/natives directory.

