### PR TITLE
bumping version of inmoov dependency to 1.1.9 

### DIFF
--- a/src/main/java/org/myrobotlab/service/InMoov.java
+++ b/src/main/java/org/myrobotlab/service/InMoov.java
@@ -2113,7 +2113,7 @@ public class InMoov extends Service implements IKJointAngleListener, JoystickLis
     meta.addCategory("robot");
     // meta.addDependency("inmoov.fr", "1.0.0");
     // meta.addDependency("org.myrobotlab.inmoov", "1.0.0");
-    meta.addDependency("inmoov.fr", "inmoov", "1.1.8", "zip");
+    meta.addDependency("inmoov.fr", "inmoov", "1.1.9", "zip");
     meta.addDependency("inmoov.fr", "jm3-model", "1.0.0", "zip");
 
     // SHARING !!! - modified key / actual name begin -------


### PR DESCRIPTION
updated version of inmoov default scripts now call startPeers() to make sure all peers are started.. it avoids a bunch of NPE exceptions and errors like no attribute load() on None type sort of errors that we were seeing.