### PR TITLE
updating to javacv 1.5.1 also explicitly defining javax.xml.bind as a dependency for java11 support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,15 @@
   </dependency>
 <!-- Elasticsearch end -->
 
+<!-- Esp8266_01 begin -->
+  <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
+      <scope>provided</scope>
+  </dependency>
+<!-- Esp8266_01 end -->
+
 <!-- GoogleCloud begin -->
   <dependency>
     <groupId>com.google.cloud</groupId>
@@ -926,13 +935,13 @@
   <dependency>
     <groupId>org.bytedeco</groupId>
     <artifactId>javacv</artifactId>
-    <version>1.5</version>
+    <version>1.5.1</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>org.bytedeco</groupId>
     <artifactId>javacv-platform</artifactId>
-    <version>1.5</version>
+    <version>1.5.1</version>
     <scope>provided</scope>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1303,9 +1303,9 @@
 
 <!-- TesseractOcr begin -->
   <dependency>
-    <groupId>org.bytedeco.javacpp-presets</groupId>
+    <groupId>org.bytedeco</groupId>
     <artifactId>tesseract-platform</artifactId>
-    <version>4.0.0-rc2-1.4.3</version>
+    <version>4.1.0-1.5.1</version>
     <scope>provided</scope>
   </dependency>
 <!-- TesseractOcr end -->

--- a/src/main/java/org/myrobotlab/service/Esp8266_01.java
+++ b/src/main/java/org/myrobotlab/service/Esp8266_01.java
@@ -118,6 +118,7 @@ public class Esp8266_01 extends Service implements I2CController {
 
     Gson gson = new Gson();
 
+    // https://github.com/MyRobotLab/myrobotlab/issues/525
     String stringBuffer = javax.xml.bind.DatatypeConverter.printHexBinary(buffer);
 
     i2cParms senddata = new i2cParms();
@@ -282,6 +283,7 @@ public class Esp8266_01 extends Service implements I2CController {
 
     Gson gson = new Gson();
 
+    // https://github.com/MyRobotLab/myrobotlab/issues/525
     String stringBuffer = javax.xml.bind.DatatypeConverter.printHexBinary(writeBuffer);
 
     i2cParms senddata = new i2cParms();
@@ -412,6 +414,9 @@ public class Esp8266_01 extends Service implements I2CController {
     meta.addDescription("ESP8266-01 service to communicate using WiFi and i2c");
     meta.addCategory("i2c", "control");
     meta.setSponsor("Mats");
+    // Java11 support : TODO: get rid of this dependency
+    // https://github.com/MyRobotLab/myrobotlab/issues/525
+    meta.addDependency("javax.xml.bind", "jaxb-api", "2.3.1");
     // meta.addDependency("org.apache.commons.httpclient", "4.5.2");
     // FIXME - add HttpClient as a peer .. and use its interface .. :)
     // then remove direct dependencies to httpcomponents ...

--- a/src/main/java/org/myrobotlab/service/OpenCV.java
+++ b/src/main/java/org/myrobotlab/service/OpenCV.java
@@ -396,7 +396,7 @@ public class OpenCV extends AbstractComputerVision {
     // meta.addPeer("streamer", "VideoStreamer", "video streaming service
     meta.sharePeer("streamer", "streamer", "VideoStreamer", "Shared Video Streamer");
 
-    String javaCvVersion = "1.5";
+    String javaCvVersion = "1.5.1";
     meta.addDependency("org.bytedeco", "javacv", javaCvVersion);
     meta.addDependency("org.bytedeco", "javacv-platform", javaCvVersion);
 

--- a/src/main/java/org/myrobotlab/service/TesseractOcr.java
+++ b/src/main/java/org/myrobotlab/service/TesseractOcr.java
@@ -120,7 +120,7 @@ public class TesseractOcr extends Service {
     ServiceType meta = new ServiceType(TesseractOcr.class);
     meta.addDescription("Optical character recognition - the ability to read");
     meta.addCategory("intelligence");
-    meta.addDependency("org.bytedeco.javacpp-presets", "tesseract-platform", "4.0.0-rc2-1.4.3");
+    meta.addDependency("org.bytedeco", "tesseract-platform", "4.1.0-1.5.1");
     return meta;
   }
 

--- a/src/main/java/org/myrobotlab/service/TesseractOcr.java
+++ b/src/main/java/org/myrobotlab/service/TesseractOcr.java
@@ -1,7 +1,7 @@
 package org.myrobotlab.service;
 
-import static org.bytedeco.javacpp.lept.pixDestroy;
-import static org.bytedeco.javacpp.lept.pixRead;
+import static org.bytedeco.leptonica.global.lept.pixDestroy;
+import static org.bytedeco.leptonica.global.lept.pixRead;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -11,8 +11,8 @@ import java.io.IOException;
 import javax.imageio.ImageIO;
 
 import org.bytedeco.javacpp.BytePointer;
-import org.bytedeco.javacpp.lept.PIX;
-import org.bytedeco.javacpp.tesseract.TessBaseAPI;
+import org.bytedeco.leptonica.PIX;
+import org.bytedeco.tesseract.TessBaseAPI;
 import org.myrobotlab.framework.Service;
 import org.myrobotlab.framework.ServiceType;
 import org.myrobotlab.image.SerializableImage;


### PR DESCRIPTION
I think the current pom.xml file is a bit out of sync with the template.  When I re-generated it, there were a bunch of properties and stuff that changed.  So, for this PR, i've only updated the pom with the new versions/dependencies.