### PR TITLE
updates for javacpp 1.5.1 (and opencv 4.1.0-1.5.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,7 @@
     <groupId>org.bytedeco</groupId>
     <artifactId>javacpp</artifactId>
     <version>1.5.1</version>
+    <scope>provided</scope>
 </dependency>
   
   <!-- https://mvnrepository.com/artifact/org.bytedeco.javacpp-presets/openblas -->
@@ -267,18 +268,21 @@
     <groupId>org.bytedeco</groupId>
     <artifactId>openblas-platform</artifactId>
     <version>0.3.6-1.5.1</version>
+    <scope>provided</scope>
 </dependency>
 <!-- https://mvnrepository.com/artifact/org.bytedeco/hdf5 -->
 <dependency>
     <groupId>org.bytedeco</groupId>
     <artifactId>hdf5</artifactId>
     <version>1.10.5-1.5.1</version>
+    <scope>provided</scope>
 </dependency>
 <!-- https://mvnrepository.com/artifact/org.bytedeco/hdf5-platform -->
 <dependency>
     <groupId>org.bytedeco</groupId>
     <artifactId>hdf5-platform</artifactId>
     <version>1.10.5-1.5.1</version>
+    <scope>provided</scope>
 </dependency>
 
   
@@ -1328,12 +1332,14 @@
     <groupId>org.bytedeco</groupId>
     <artifactId>tesseract-platform</artifactId>
     <version>4.1.0-1.5.1</version>
+    <scope>provided</scope>
 </dependency>
 
 <dependency>
     <groupId>org.bytedeco</groupId>
     <artifactId>tesseract</artifactId>
     <version>4.1.0-1.5.1</version>
+    <scope>provided</scope>
 </dependency>
 
 <!--  TODO: fix me

--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,36 @@
     <version>3.1.1</version>
     <scope>provided</scope>
   </dependency>
+  
+  <!--  TODO: fix me these need to be updated for 1.5.1 javacpp stuffs -->
+  <!-- https://mvnrepository.com/artifact/org.bytedeco/javacpp -->
+<dependency>
+    <groupId>org.bytedeco</groupId>
+    <artifactId>javacpp</artifactId>
+    <version>1.5.1</version>
+</dependency>
+  
+  <!-- https://mvnrepository.com/artifact/org.bytedeco.javacpp-presets/openblas -->
+  <!-- https://mvnrepository.com/artifact/org.bytedeco/openblas-platform -->
+<dependency>
+    <groupId>org.bytedeco</groupId>
+    <artifactId>openblas-platform</artifactId>
+    <version>0.3.6-1.5.1</version>
+</dependency>
+<!-- https://mvnrepository.com/artifact/org.bytedeco/hdf5 -->
+<dependency>
+    <groupId>org.bytedeco</groupId>
+    <artifactId>hdf5</artifactId>
+    <version>1.10.5-1.5.1</version>
+</dependency>
+<!-- https://mvnrepository.com/artifact/org.bytedeco/hdf5-platform -->
+<dependency>
+    <groupId>org.bytedeco</groupId>
+    <artifactId>hdf5-platform</artifactId>
+    <version>1.10.5-1.5.1</version>
+</dependency>
+
+  
 <!-- Deeplearning4j end -->
 
 <!-- DocumentPipeline begin -->
@@ -926,13 +956,13 @@
   <dependency>
     <groupId>org.bytedeco</groupId>
     <artifactId>javacv</artifactId>
-    <version>1.5</version>
+    <version>1.5.1</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>org.bytedeco</groupId>
     <artifactId>javacv-platform</artifactId>
-    <version>1.5</version>
+    <version>1.5.1</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
@@ -1293,12 +1323,27 @@
 <!-- Tensorflow end -->
 
 <!-- TesseractOcr begin -->
+<!-- https://mvnrepository.com/artifact/org.bytedeco/tesseract-platform -->
+<dependency>
+    <groupId>org.bytedeco</groupId>
+    <artifactId>tesseract-platform</artifactId>
+    <version>4.1.0-1.5.1</version>
+</dependency>
+
+<dependency>
+    <groupId>org.bytedeco</groupId>
+    <artifactId>tesseract</artifactId>
+    <version>4.1.0-1.5.1</version>
+</dependency>
+
+<!--  TODO: fix me
+
   <dependency>
     <groupId>org.bytedeco.javacpp-presets</groupId>
     <artifactId>tesseract-platform</artifactId>
     <version>4.0.0-rc2-1.4.3</version>
     <scope>provided</scope>
-  </dependency>
+  </dependency>  -->
 <!-- TesseractOcr end -->
 
 <!-- Test begin -->

--- a/src/main/java/org/myrobotlab/service/Deeplearning4j.java
+++ b/src/main/java/org/myrobotlab/service/Deeplearning4j.java
@@ -858,7 +858,17 @@ public class Deeplearning4j extends Service {
     meta.addDependency("org.deeplearning4j", "deeplearning4j-modelimport", dl4jVersion);
     // TODO: which scala version?! for now 2.11
     meta.addDependency("org.deeplearning4j", "deeplearning4j-ui_2.11", dl4jVersion);
-
+    // pull in a newer one from opencv / tesseract.
+    //meta.exclude("org.bytedeco", "javacpp");
+    // force a newer version of javacpp for this.
+    // we need to force some newer versions of various javacpp packages to newer versions to avoid
+    // conflicts with opencv 1.5.1 ...
+    meta.addDependency("org.bytedeco", "javacpp", "1.5.1");
+    meta.addDependency("org.bytedeco", "openblas", "0.3.6-1.5.1");
+    meta.addDependency("org.bytedeco", "openblas-platform", "0.3.6-1.5.1");
+    meta.addDependency("org.bytedeco", "hdf5", "1.10.5-1.5.1");
+    meta.addDependency("org.bytedeco", "hdf5-platform", "1.10.5-1.5.1");
+    
     if (!cudaEnabled) {
       // By default support native CPU execution.
       meta.addDependency("org.nd4j", "nd4j-native-platform", dl4jVersion);

--- a/src/main/java/org/myrobotlab/service/TesseractOcr.java
+++ b/src/main/java/org/myrobotlab/service/TesseractOcr.java
@@ -120,6 +120,7 @@ public class TesseractOcr extends Service {
     ServiceType meta = new ServiceType(TesseractOcr.class);
     meta.addDescription("Optical character recognition - the ability to read");
     meta.addCategory("intelligence");
+    meta.addDependency("org.bytedeco", "tesseract", "4.1.0-1.5.1");
     meta.addDependency("org.bytedeco", "tesseract-platform", "4.1.0-1.5.1");
     return meta;
   }


### PR DESCRIPTION
I think this gets the javacv 1.5.1 upgrade done.. needed to manually override a bunch of stuff pulled in from dl4j to avoid conflicts with javacpp 1.5