### PR TITLE
making the yolo and dl4j classifier threads enable and siable with the filters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: java
 sudo: false
 script: mvn install -DskipTests=true 
 jdk:
-- oraclejdk8
+- openjdk8
 
 # deploy:
 #   provider: s3

--- a/src/main/java/org/myrobotlab/opencv/OpenCVFilterDL4J.java
+++ b/src/main/java/org/myrobotlab/opencv/OpenCVFilterDL4J.java
@@ -143,6 +143,17 @@ public class OpenCVFilterDL4J extends OpenCVFilter implements Runnable {
     running = true;
     // in a loop, grab the current image and classify it and update the result.
     while (running) {// FIXME - must be able to release !!
+      
+      if (!enabled) {
+        // sleep to avoid cpu usage
+        // TODO: come up with a better way of doing this (maybe shutdown this thread and restart when it enables/disbales?)
+        try {
+          Thread.sleep(10);
+        } catch (InterruptedException e) {
+          log.info("Dl4j classifier thread interrupted", e);
+        }
+        continue;
+      }
       // log.info("Running!!!");
       // now we need to know which image we should classify
       // there likely needs to be some synchronization on this too.. o/w the

--- a/src/main/java/org/myrobotlab/opencv/OpenCVFilterYolo.java
+++ b/src/main/java/org/myrobotlab/opencv/OpenCVFilterYolo.java
@@ -207,7 +207,9 @@ public class OpenCVFilterYolo extends OpenCVFilter implements Runnable {
     // ok now we just need to update the image that the current thread is
     // processing (if the current thread is idle i guess?)
     lastImage = image;
-    pending = true;
+    if (enabled) {
+      pending = true;
+    }
     return image;
   }
 


### PR DESCRIPTION
currently when you disable the yolo and dl4j filters in opencv the threads still continue trying to process the image frames in the background.   now when the fitlers are disabled, the threads will go to sleep ..