### PR TITLE
Caching time encoder positions

### DIFF
--- a/src/main/java/org/myrobotlab/framework/Service.java
+++ b/src/main/java/org/myrobotlab/framework/Service.java
@@ -148,7 +148,7 @@ public abstract class Service implements Runnable, Serializable, ServiceInterfac
   /**
    * for promoting portability and good pathing
    */
-  transient protected String fs = File.separator;
+  transient protected static String fs = File.separator;
 
   /**
    * for promoting portability and good pathing
@@ -782,14 +782,18 @@ public abstract class Service implements Runnable, Serializable, ServiceInterfac
   public String getHomeDir() {
     return System.getProperty("user.home");
   }
-
-  public String getDataDir() {
-    String dataDir = Runtime.getOptions().dataDir + fs + getClass().getSimpleName();
+  
+  static public String getDataDir(String typeName) {
+    String dataDir = Runtime.getOptions().dataDir + fs + typeName;
     File f = new File(dataDir);
     if (!f.exists()) {
       f.mkdirs();
     }
-    return Runtime.getOptions().dataDir + fs + getClass().getSimpleName();
+    return Runtime.getOptions().dataDir + fs + typeName;
+  }
+
+  public String getDataDir() {
+    return getDataDir(getClass().getSimpleName());
   }
 
   public String getDataInstanceDir() {

--- a/src/main/java/org/myrobotlab/sensor/TimeEncoder.java
+++ b/src/main/java/org/myrobotlab/sensor/TimeEncoder.java
@@ -360,7 +360,6 @@ public class TimeEncoder implements Runnable, EncoderControl {
     return estimatedPos;
   }
 
-  @Override
   public void setPos(Double pos) {
     beginPos = targetPos = estimatedPos = pos;
     positions.setPosition(name, estimatedPos);

--- a/src/main/java/org/myrobotlab/sensor/TimeEncoder.java
+++ b/src/main/java/org/myrobotlab/sensor/TimeEncoder.java
@@ -117,7 +117,7 @@ public class TimeEncoder implements Runnable, EncoderControl {
       while (running) {
         try {
           Thread.sleep(2000);
-          log.info("saving {} positions of {} servos", filename, positions.size());
+          log.debug("saving {} positions of {} servos", filename, positions.size());
           FileIO.toFile(filename, CodecUtils.toJson(positions).getBytes());
         } catch (Exception e) {
           log.error("could not save servo positions", e);
@@ -144,7 +144,7 @@ public class TimeEncoder implements Runnable, EncoderControl {
       }
     }
 
-    public void setPos(String name, double pos) {
+    public void setPosition(String name, double pos) {
       positions.put(name, pos);
     }
 
@@ -247,6 +247,8 @@ public class TimeEncoder implements Runnable, EncoderControl {
           // log.info(String.format("new pos %.2f", estimatedPos)); helpful to
           // debug
           EncoderData d = new EncoderData(name, null, estimatedPos);
+
+          positions.setPosition(name, estimatedPos);
           servo.onEncoderData(d);
           Service.sleep(sampleIntervalMs);
         }
@@ -255,7 +257,7 @@ public class TimeEncoder implements Runnable, EncoderControl {
         // log.info("finished moved");
         EncoderData d = new EncoderData(name, null, estimatedPos);
         servo.onEncoderData(d);
-        positions.setPos(name, estimatedPos);
+        positions.setPosition(name, estimatedPos);
       }
     } catch (InterruptedException e) {
       log.info("stopping TimeEncoder Timer ...");

--- a/src/main/java/org/myrobotlab/sensor/TimeEncoder.java
+++ b/src/main/java/org/myrobotlab/sensor/TimeEncoder.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.myrobotlab.codec.CodecUtils;
 import org.myrobotlab.framework.Service;
@@ -88,7 +89,7 @@ public class TimeEncoder implements Runnable, EncoderControl {
   static class Positions implements Runnable {
 
     static Positions instance = null;
-    Map<String, Double> positions = new HashMap<>();
+    Map<String, Double> positions = new ConcurrentHashMap<>();
     transient private Thread worker;
     transient boolean running = false;
     String filename = null;
@@ -105,7 +106,7 @@ public class TimeEncoder implements Runnable, EncoderControl {
       } catch (Exception e) {
       }
       if (json != null) {
-        positions = CodecUtils.fromJson(json, HashMap.class);
+        positions = CodecUtils.fromJson(json, ConcurrentHashMap.class);
       }
     }
 

--- a/src/main/java/org/myrobotlab/sensor/TimeEncoder.java
+++ b/src/main/java/org/myrobotlab/sensor/TimeEncoder.java
@@ -167,6 +167,7 @@ public class TimeEncoder implements Runnable, EncoderControl {
 
   public TimeEncoder(ServoControl servo) {
     this.servo = servo;
+    this.name = servo.getName();
     positions = Positions.getInstance();
     Double p = positions.getPosition(servo.getName());
     if (p != null) {
@@ -197,8 +198,7 @@ public class TimeEncoder implements Runnable, EncoderControl {
     // leave if timets > endMoveTs or if canceled with new move
     // while()
     now = beginMoveTs;
-    name = servo.getName();
-
+    
     if (autoProcess) { // vs buffer ?
       processTrajectory(name);
     }
@@ -358,6 +358,12 @@ public class TimeEncoder implements Runnable, EncoderControl {
   @Override
   public Double getPos() {
     return estimatedPos;
+  }
+
+  @Override
+  public void setPos(Double pos) {
+    beginPos = targetPos = estimatedPos = pos;
+    positions.setPosition(name, estimatedPos);
   }
 
 }

--- a/src/main/java/org/myrobotlab/service/LegacyServo.java
+++ b/src/main/java/org/myrobotlab/service/LegacyServo.java
@@ -691,7 +691,7 @@ public class LegacyServo extends Service implements ServoControl {
   }
   
   @Override
-  public void unsetSpeed() {
+  public void disableSpeedControl() {
     log.info("disabling speed control");
     velocity = null;
     broadcastState();

--- a/src/main/java/org/myrobotlab/service/abstracts/AbstractPinEncoder.java
+++ b/src/main/java/org/myrobotlab/service/abstracts/AbstractPinEncoder.java
@@ -111,4 +111,11 @@ public class AbstractPinEncoder extends Service implements EncoderControl {
   public Double getPos() {
     return lastPosition;
   }
+
+  @Override
+  public void setPos(Double offset) {
+    // FIXME - should this set an offset to angle ?
+    // e.g. angle + offset
+    
+  }
 }

--- a/src/main/java/org/myrobotlab/service/abstracts/AbstractPinEncoder.java
+++ b/src/main/java/org/myrobotlab/service/abstracts/AbstractPinEncoder.java
@@ -111,11 +111,4 @@ public class AbstractPinEncoder extends Service implements EncoderControl {
   public Double getPos() {
     return lastPosition;
   }
-
-  @Override
-  public void setPos(Double offset) {
-    // FIXME - should this set an offset to angle ?
-    // e.g. angle + offset
-    
-  }
 }

--- a/src/main/java/org/myrobotlab/service/abstracts/AbstractPinEncoder.java
+++ b/src/main/java/org/myrobotlab/service/abstracts/AbstractPinEncoder.java
@@ -106,4 +106,9 @@ public class AbstractPinEncoder extends Service implements EncoderControl {
   public EncoderData publishEncoderData(EncoderData data) {
     return data;
   }
+
+  @Override
+  public Double getPos() {
+    return lastPosition;
+  }
 }

--- a/src/main/java/org/myrobotlab/service/abstracts/AbstractServo.java
+++ b/src/main/java/org/myrobotlab/service/abstracts/AbstractServo.java
@@ -955,6 +955,9 @@ public abstract class AbstractServo extends Service implements ServoControl {
   @Override
   public void setPosition(Double pos) {
     currentPos = targetPos = pos;
+    if (encoder != null) {
+      encoder.setPos(pos);
+    }
     broadcastState();
   }
 

--- a/src/main/java/org/myrobotlab/service/abstracts/AbstractServo.java
+++ b/src/main/java/org/myrobotlab/service/abstracts/AbstractServo.java
@@ -238,6 +238,11 @@ public abstract class AbstractServo extends Service implements ServoControl {
     // create our default TimeEncoder
     if (encoder == null) {
       encoder = new TimeEncoder(this);
+      // if the encoder has a current value - we initialize the
+      // servo with that value
+      if (encoder.getPos() != null) {
+        currentPos = targetPos = encoder.getPos();
+      }
     }
   }
 
@@ -990,7 +995,7 @@ public abstract class AbstractServo extends Service implements ServoControl {
   }
   
   @Override
-  public void unsetSpeed() {
+  public void disableSpeedControl() {
     log.info("disabling speed control");
     speed = null;
     if (controller != null) {
@@ -1003,7 +1008,7 @@ public abstract class AbstractServo extends Service implements ServoControl {
   @Config
   public void setSpeed(Double degreesPerSecond) {
     if (degreesPerSecond == null) {
-      unsetSpeed();
+      disableSpeedControl();
       return;
     }
 

--- a/src/main/java/org/myrobotlab/service/abstracts/AbstractServo.java
+++ b/src/main/java/org/myrobotlab/service/abstracts/AbstractServo.java
@@ -240,7 +240,9 @@ public abstract class AbstractServo extends Service implements ServoControl {
       encoder = new TimeEncoder(this);
       // if the encoder has a current value - we initialize the
       // servo with that value
-      if (encoder.getPos() != null) {
+      Double savedPos = encoder.getPos();
+      if (savedPos != null) {
+        log.info("found previous values for {} setting initial position to {}", getName(), savedPos );
         currentPos = targetPos = encoder.getPos();
       }
     }

--- a/src/main/java/org/myrobotlab/service/abstracts/AbstractServo.java
+++ b/src/main/java/org/myrobotlab/service/abstracts/AbstractServo.java
@@ -956,7 +956,8 @@ public abstract class AbstractServo extends Service implements ServoControl {
   public void setPosition(Double pos) {
     currentPos = targetPos = pos;
     if (encoder != null) {
-      encoder.setPos(pos);
+      if (encoder instanceof TimeEncoder )
+      ((TimeEncoder)encoder).setPos(pos);
     }
     broadcastState();
   }

--- a/src/main/java/org/myrobotlab/service/interfaces/EncoderControl.java
+++ b/src/main/java/org/myrobotlab/service/interfaces/EncoderControl.java
@@ -23,8 +23,6 @@ public interface EncoderControl extends Attachable {
    * @return data
    */
   public EncoderData publishEncoderData(EncoderData data);
-  
- 
 
   /**
    * return the state of streaming encoder data
@@ -38,8 +36,5 @@ public interface EncoderControl extends Attachable {
    * @return
    */
   public Double getPos();
-  
-  
-  public void setPos(Double pos);
 
 }

--- a/src/main/java/org/myrobotlab/service/interfaces/EncoderControl.java
+++ b/src/main/java/org/myrobotlab/service/interfaces/EncoderControl.java
@@ -23,6 +23,8 @@ public interface EncoderControl extends Attachable {
    * @return data
    */
   public EncoderData publishEncoderData(EncoderData data);
+  
+ 
 
   /**
    * return the state of streaming encoder data
@@ -36,5 +38,8 @@ public interface EncoderControl extends Attachable {
    * @return
    */
   public Double getPos();
+  
+  
+  public void setPos(Double pos);
 
 }

--- a/src/main/java/org/myrobotlab/service/interfaces/EncoderControl.java
+++ b/src/main/java/org/myrobotlab/service/interfaces/EncoderControl.java
@@ -31,4 +31,10 @@ public interface EncoderControl extends Attachable {
    */
   public Boolean isEnabled();
 
+  /**
+   * the position of the encoder in degrees or cm for linear encoder ?
+   * @return
+   */
+  public Double getPos();
+
 }

--- a/src/main/java/org/myrobotlab/service/interfaces/ServoControl.java
+++ b/src/main/java/org/myrobotlab/service/interfaces/ServoControl.java
@@ -388,7 +388,7 @@ public interface ServoControl extends AbsolutePositionControl, EncoderListener, 
   /**
    * remove speed control
    */
-  public void unsetSpeed();
+  public void disableSpeedControl();
 
   Double getTargetPos();
 

--- a/src/main/resources/resource/WebGui/app/service/js/ServoGui.js
+++ b/src/main/resources/resource/WebGui/app/service/js/ServoGui.js
@@ -159,7 +159,13 @@ angular.module('mrlapp.service.ServoGui', []).controller('ServoGuiCtrl', ['$log'
     }
     $scope.attachController = function() {
         $log.info("attachController")
-        msg.send('attach', $scope.possibleController, $scope.pin, $scope.rest)
+
+        // FIXME - there needs to be some updates to handle the complexity of taking updates from the servo vs
+        // taking updates from the UI ..  some of this would be clearly solved with a (control/status) button
+
+        let pos = $scope.pos.value; // currently taken from the slider's value :P - not good if the slider's value is not good :(
+        
+        msg.send('attach', $scope.possibleController, $scope.pin, pos) // $scope.rest) <-- previously used rest which is (not good)
         // msg.attach($scope.controller, $scope.pin, 90)
     }
 


### PR DESCRIPTION
Servos using time encoders how have checkpoints to save their 'current' position
this can substantially reduce crazy coffee moves on startup