### PR TITLE
minimal set of backwards compatability for legacy inmoov scripts

### DIFF
--- a/src/main/java/org/myrobotlab/service/Servo.java
+++ b/src/main/java/org/myrobotlab/service/Servo.java
@@ -202,6 +202,10 @@ public class Servo extends AbstractServo implements ServoControl {
     setAutoDisable(value);
   }
 
+  @Deprecated
+  public void setMaxVelocity(Double velocity) {
+    log.warn("SetMaxVelocity does nothing and is deprecated. please update your python scripts, and use fullSpeed() instead");
+  }
   
   public static void main(String[] args) throws InterruptedException {
     try {

--- a/src/main/java/org/myrobotlab/service/abstracts/AbstractSpeechRecognizer.java
+++ b/src/main/java/org/myrobotlab/service/abstracts/AbstractSpeechRecognizer.java
@@ -501,6 +501,14 @@ public abstract class AbstractSpeechRecognizer extends Service implements Speech
     broadcastState();
   }
 
+  /* use startListening() */
+  @Deprecated
+  public void setAutoListen(Boolean value) {
+    if (value) 
+      startListening();
+    else 
+      stopListening();
+  }
   /**
    * for webkit - startRecognizer consists of setting a property and
    * broadcasting self to the webgui

--- a/src/main/java/org/myrobotlab/service/abstracts/AbstractSpeechRecognizer.java
+++ b/src/main/java/org/myrobotlab/service/abstracts/AbstractSpeechRecognizer.java
@@ -504,6 +504,7 @@ public abstract class AbstractSpeechRecognizer extends Service implements Speech
   /* use startListening() */
   @Deprecated
   public void setAutoListen(Boolean value) {
+    log.warn("Set Auto listen deprecated, use startListening() or stopListening() instead.");
     if (value) 
       startListening();
     else 

--- a/src/test/java/org/myrobotlab/service/ServoTest.java
+++ b/src/test/java/org/myrobotlab/service/ServoTest.java
@@ -157,7 +157,7 @@ public class ServoTest extends AbstractTest {
     log.warn("thread list {}", getThreadNames());
     assertTrue("setting autoDisable true", servo01.isAutoDisable());
     servo01.moveTo(2.0);
-    sleep(servo01.getIdleTimeout()+500); // waiting for disable
+    sleep(servo01.getIdleTimeout()+1000); // waiting for disable
     assertFalse("servo should have been disabled", servo01.isEnabled());
     
     assertEquals(2.0, servo01.getCurrentInputPos(), 0.0001);


### PR DESCRIPTION
with these two helper methods, the original inmoov scripts will run without modification.  these methods are marked as deprecated and are only here for backwards compatibility for some legacy scripts.