### PR TITLE
process cli cleanup

### DIFF
--- a/src/main/java/org/myrobotlab/service/Blender.java
+++ b/src/main/java/org/myrobotlab/service/Blender.java
@@ -78,10 +78,12 @@ public class Blender extends Service {
 
   private static final long serialVersionUID = 1L;
 
-  public final static Logger log = LoggerFactory.getLogger(Blender.class);
+  transient public final static Logger log = LoggerFactory.getLogger(Blender.class);
 
   public static final String SUCCESS = "SUCCESS";
-  Socket control = null;
+  
+  transient Socket control = null;
+  
   transient ControlHandler controlHandler = null;
 
   String host = "localhost";

--- a/src/main/java/org/myrobotlab/service/Python.java
+++ b/src/main/java/org/myrobotlab/service/Python.java
@@ -603,7 +603,7 @@ public class Python extends Service {
   public void onStarted(String serviceName) {
     ServiceInterface s = Runtime.getService(serviceName);
     if (s == null) {
-      error("%s got started event from {} yet does not exist in registry", getName(), serviceName);
+      error("%s got started event from %s yet does not exist in registry", getName(), serviceName);
       return;
     }
 

--- a/src/main/java/org/myrobotlab/service/Runtime.java
+++ b/src/main/java/org/myrobotlab/service/Runtime.java
@@ -3451,8 +3451,8 @@ public class Runtime extends Service implements MessageListener, ServiceLifeCycl
       // msg
       // but just in case ...
       for (Object o : msg.data) {
-        if (msg.method.equals("remoteRegister")) {
-          System.out.println(String.format("remoteRegister %s for %s", ((Registration) msg.data[0]).getName(), msg.name));
+        if (o instanceof Registration) {
+          System.out.println(String.format("%s %s for %s", msg.method, ((Registration) msg.data[0]).getName(), msg.name));
         } else {
           System.out.println(CodecUtils.toPrettyJson(o));
         }

--- a/src/test/java/org/myrobotlab/service/InProcessCliTest.java
+++ b/src/test/java/org/myrobotlab/service/InProcessCliTest.java
@@ -1,6 +1,5 @@
 package org.myrobotlab.service;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
@@ -8,14 +7,10 @@ import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.myrobotlab.client.InProcessCli;
 import org.myrobotlab.codec.CodecUtils;
-import org.myrobotlab.service.Runtime;
 import org.myrobotlab.test.AbstractTest;
 
 public class InProcessCliTest extends AbstractTest {
@@ -31,18 +26,6 @@ public class InProcessCliTest extends AbstractTest {
     bos = new ByteArrayOutputStream();
   }
 
-  @AfterClass
-  public static void tearDownAfterClass() throws Exception {
-  }
-
-  @Before
-  public void setUp() throws Exception {
-  }
-
-  @After
-  public void tearDown() throws Exception {
-  }
-  
   public void write(String str) throws IOException {
     pipe.write((str + "\n").getBytes());
     // must read it off and process the data

--- a/src/test/java/org/myrobotlab/service/ServiceInterfaceTest.java
+++ b/src/test/java/org/myrobotlab/service/ServiceInterfaceTest.java
@@ -74,12 +74,13 @@ public class ServiceInterfaceTest extends AbstractTest {
     // TODO: add a bunch more tests here!
     foo.startService();
     foo.stopService();
-    foo.releaseService();
 
     foo.startService();
     foo.save();
     foo.load();
     foo.stopService();
+
+    foo.releaseService();
 
     return true;
   }
@@ -115,6 +116,7 @@ public class ServiceInterfaceTest extends AbstractTest {
     
     // start up python so we have it available to do some testing with.
     Python python = (Python) Runtime.start("python", "Python");
+    Service.sleep(1000);
     ServiceData sd = ServiceData.getLocalInstance();
     List<MetaData> sts = sd.getServiceTypes(); // there is also sd.getAvailableServiceTypes();
     


### PR DESCRIPTION
ServiceInterfaceTest was releasing then starting again then stopping.  This is invalid in the service lifecycle.  Once released, a service should not be restarted.  Using the Runtime.create or start for the same service would be valid, but not si.releaseService(), si.startService()

