### PR TITLE
Neopixel depth steve

### DIFF
--- a/src/main/java/org/myrobotlab/arduino/ArduinoMsgGenerator.java
+++ b/src/main/java/org/myrobotlab/arduino/ArduinoMsgGenerator.java
@@ -26,7 +26,7 @@ public class ArduinoMsgGenerator {
 
   public transient final static Logger log = LoggerFactory.getLogger(ArduinoMsgGenerator.class);
 
-  static final Integer MRLCOMM_VERSION = 66;
+  static final Integer MRLCOMM_VERSION = 67;
 
   private String ackEnabled = "true";
 

--- a/src/main/java/org/myrobotlab/arduino/Msg.java
+++ b/src/main/java/org/myrobotlab/arduino/Msg.java
@@ -69,7 +69,7 @@ public class Msg {
   public transient final static Logger log = LoggerFactory.getLogger(Msg.class);
   public static final int MAX_MSG_SIZE = 64;
   public static final int MAGIC_NUMBER = 170; // 10101010
-  public static final int MRLCOMM_VERSION = 66;
+  public static final int MRLCOMM_VERSION = 67;
   // send buffer
   private int sendBufferSize = 0;
   private int sendBuffer[] = new int[MAX_MSG_SIZE];
@@ -148,7 +148,7 @@ public class Msg {
   public final static int I2C_WRITE_READ = 18;
   // < publishI2cData/deviceId/[] data
   public final static int PUBLISH_I2C_DATA = 19;
-  // > neoPixelAttach/deviceId/pin/b32 numPixels
+  // > neoPixelAttach/deviceId/pin/b32 numPixels/depth
   public final static int NEO_PIXEL_ATTACH = 20;
   // > neoPixelSetAnimation/deviceId/animation/red/green/blue/b16 speed
   public final static int NEO_PIXEL_SET_ANIMATION = 21;
@@ -1082,18 +1082,19 @@ public class Msg {
     }
   }
 
-  public synchronized byte[] neoPixelAttach(Integer deviceId/*byte*/, Integer pin/*byte*/, Integer numPixels/*b32*/) {
+  public synchronized byte[] neoPixelAttach(Integer deviceId/*byte*/, Integer pin/*byte*/, Integer numPixels/*b32*/, Integer depth/*byte*/) {
     if (debug) {
       log.info("Sending Message: neoPixelAttach to {}", serial.getName());
     }
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     try {
       appendMessage(baos, MAGIC_NUMBER);
-      appendMessage(baos, 1 + 1 + 1 + 4); // size
+      appendMessage(baos, 1 + 1 + 1 + 4 + 1); // size
       appendMessage(baos, NEO_PIXEL_ATTACH); // msgType = 20
       appendMessage(baos, deviceId);
       appendMessage(baos, pin);
       appendMessageb32(baos, numPixels);
+      appendMessage(baos, depth);
  
       byte[] message = sendMessage(baos);
       if (ackEnabled){
@@ -1107,6 +1108,8 @@ public class Msg {
         txBuffer.append(pin);
         txBuffer.append("/");
         txBuffer.append(numPixels);
+        txBuffer.append("/");
+        txBuffer.append(depth);
         txBuffer.append("\n");
         record.write(txBuffer.toString().getBytes());
         txBuffer.setLength(0);

--- a/src/main/java/org/myrobotlab/arduino/VirtualMsg.java
+++ b/src/main/java/org/myrobotlab/arduino/VirtualMsg.java
@@ -69,7 +69,7 @@ public class VirtualMsg {
   public transient final static Logger log = LoggerFactory.getLogger(VirtualMsg.class);
   public static final int MAX_MSG_SIZE = 64;
   public static final int MAGIC_NUMBER = 170; // 10101010
-  public static final int MRLCOMM_VERSION = 66;
+  public static final int MRLCOMM_VERSION = 67;
   // send buffer
   private int sendBufferSize = 0;
   private int sendBuffer[] = new int[MAX_MSG_SIZE];
@@ -148,7 +148,7 @@ public class VirtualMsg {
   public final static int I2C_WRITE_READ = 18;
   // < publishI2cData/deviceId/[] data
   public final static int PUBLISH_I2C_DATA = 19;
-  // > neoPixelAttach/deviceId/pin/b32 numPixels
+  // > neoPixelAttach/deviceId/pin/b32 numPixels/depth
   public final static int NEO_PIXEL_ATTACH = 20;
   // > neoPixelSetAnimation/deviceId/animation/red/green/blue/b16 speed
   public final static int NEO_PIXEL_SET_ANIMATION = 21;
@@ -241,7 +241,7 @@ public class VirtualMsg {
   // public void i2cRead(Integer deviceId/*byte*/, Integer deviceAddress/*byte*/, Integer size/*byte*/){}
   // public void i2cWrite(Integer deviceId/*byte*/, Integer deviceAddress/*byte*/, int[] data/*[]*/){}
   // public void i2cWriteRead(Integer deviceId/*byte*/, Integer deviceAddress/*byte*/, Integer readSize/*byte*/, Integer writeValue/*byte*/){}
-  // public void neoPixelAttach(Integer deviceId/*byte*/, Integer pin/*byte*/, Integer numPixels/*b32*/){}
+  // public void neoPixelAttach(Integer deviceId/*byte*/, Integer pin/*byte*/, Integer numPixels/*b32*/, Integer depth/*byte*/){}
   // public void neoPixelSetAnimation(Integer deviceId/*byte*/, Integer animation/*byte*/, Integer red/*byte*/, Integer green/*byte*/, Integer blue/*byte*/, Integer speed/*b16*/){}
   // public void neoPixelWriteMatrix(Integer deviceId/*byte*/, int[] buffer/*[]*/){}
   // public void analogWrite(Integer pin/*byte*/, Integer value/*byte*/){}
@@ -474,10 +474,12 @@ public class VirtualMsg {
       startPos += 1;
       Integer numPixels = b32(ioCmd, startPos+1);
       startPos += 4; //b32
+      Integer depth = ioCmd[startPos+1]; // bu8
+      startPos += 1;
       if(invoke){
-        arduino.invoke("neoPixelAttach",  deviceId,  pin,  numPixels);
+        arduino.invoke("neoPixelAttach",  deviceId,  pin,  numPixels,  depth);
       } else { 
-         arduino.neoPixelAttach( deviceId,  pin,  numPixels);
+         arduino.neoPixelAttach( deviceId,  pin,  numPixels,  depth);
       }
       break;
     }

--- a/src/main/java/org/myrobotlab/arduino/virtual/MrlComm.java
+++ b/src/main/java/org/myrobotlab/arduino/virtual/MrlComm.java
@@ -532,12 +532,12 @@ public class MrlComm implements SerialDataListener {
   }
 
   // > neoPixelAttach/pin/b16 numPixels
-  public void neoPixelAttach(int deviceId, int pin, long numPixels) {
+  public void neoPixelAttach(int deviceId, int pin, long numPixels, int depth) {
     // msg.publishDebug("MrlNeopixel.deviceAttach!");
 
     MrlNeopixel neo = (MrlNeopixel) addDevice(new MrlNeopixel(deviceId, virtual));
     virtualMsg.publishDebug("id" + String(deviceId));
-    neo.attach(pin, numPixels);
+    neo.attach(pin, numPixels, depth);
   }
 
   // > neoPixelAttach/pin/b16 numPixels

--- a/src/main/java/org/myrobotlab/arduino/virtual/MrlNeopixel.java
+++ b/src/main/java/org/myrobotlab/arduino/virtual/MrlNeopixel.java
@@ -36,7 +36,7 @@ public class MrlNeopixel extends Device {
 
   }
 
-  public void attach(int pin, long numPixels) {
+  public void attach(int pin, long numPixels, int depth) {
     // TODO Auto-generated method stub
 
   }

--- a/src/main/java/org/myrobotlab/service/Arduino.java
+++ b/src/main/java/org/myrobotlab/service/Arduino.java
@@ -1358,7 +1358,7 @@ public class Arduino extends AbstractMicrocontroller implements I2CBusController
   }
 
   @Override
-  // > neoPixelAttach/deviceId/pin/b32 numPixels
+  // > neoPixelAttach/deviceId/pin/b32 numPixels/depth
   public void neoPixelAttach(NeoPixel neopixel, int pin, int numPixels) {
     DeviceMapping dm = attachDevice(neopixel, new Object[] { pin, numPixels });
     Integer deviceId = dm.getId();

--- a/src/main/java/org/myrobotlab/service/Arduino.java
+++ b/src/main/java/org/myrobotlab/service/Arduino.java
@@ -1363,7 +1363,7 @@ public class Arduino extends AbstractMicrocontroller implements I2CBusController
     DeviceMapping dm = attachDevice(neopixel, new Object[] { pin, numPixels });
     Integer deviceId = dm.getId();
     msg.neoPixelAttach(getDeviceId(neopixel)/* byte */, pin/* byte */,
-        numPixels/* b32 */);
+        numPixels/* b32 */, neopixel.depth);
   }
 
   @Override

--- a/src/main/java/org/myrobotlab/service/NeoPixel.java
+++ b/src/main/java/org/myrobotlab/service/NeoPixel.java
@@ -218,6 +218,7 @@ public class NeoPixel extends Service implements NeoPixelControl {
     msg.add(pixel.red);
     msg.add(pixel.green);
     msg.add(pixel.blue);
+    msg.add(pixel.white);
     setPixel(pixel);
     controller.neoPixelWriteMatrix(this, msg);
     // savedPixelMatrix.clear();
@@ -234,7 +235,7 @@ public class NeoPixel extends Service implements NeoPixelControl {
   }
 
   public void sendPixel(String address, String red, String green, String blue) {
-    sendPixel(address, red, green, blue, "0.0"); 
+    sendPixel(address, red, green, blue, "0"); 
   }
   
   public void sendPixel(String address, String red, String green, String blue,String white) {
@@ -256,6 +257,7 @@ public class NeoPixel extends Service implements NeoPixelControl {
         msg.add(pix.red);
         msg.add(pix.green);
         msg.add(pix.blue);
+        msg.add(pix.white);
         pix.changed = false;
         me.setValue(pix);
       }
@@ -296,15 +298,31 @@ public class NeoPixel extends Service implements NeoPixelControl {
 
 
   public void attach(String controllerName, int pin, int numPixel) throws Exception {
-    attach((NeoPixelController) Runtime.getService(controllerName), pin, numPixel);
+    attach(controllerName, pin, numPixel, 3);
+  }
+  
+  public void attach(String controllerName, int pin, int numPixel, int depth) throws Exception {
+	attach((NeoPixelController) Runtime.getService(controllerName), pin, numPixel, depth);
   }
 
   public void attach(String controllerName, String pin, String numPixel) throws Exception {
-    attach((NeoPixelController) Runtime.getService(controllerName), Integer.parseInt(pin), Integer.parseInt(numPixel));
+    attach(controllerName, pin, numPixel, "RGB");
+  }
+  
+  public void attach(String controllerName, String pin, String numPixel, String depth) throws Exception {
+	int colorDepth = 3;
+	if (depth == "RGBW") {
+	  colorDepth = 4;
+	}
+	attach((NeoPixelController) Runtime.getService(controllerName), Integer.parseInt(pin), Integer.parseInt(numPixel), colorDepth);
   }
 
   @Override
   public void attach(NeoPixelController controller, int pin, int numPixel) {
+	  attach(controller, pin, numPixel, 3);
+  }
+  
+  public void attach(NeoPixelController controller, int pin, int numPixel, int depth) {
     if (controller == null) {
       error("setting null as controller");
       return;
@@ -316,6 +334,7 @@ public class NeoPixel extends Service implements NeoPixelControl {
 
     this.pin = pin;
     this.numPixel = numPixel;
+    this.depth = depth;
 
     // clear the old matrix
     pixelMatrix.clear();

--- a/src/main/java/org/myrobotlab/service/NeoPixel.java
+++ b/src/main/java/org/myrobotlab/service/NeoPixel.java
@@ -488,8 +488,7 @@ public class NeoPixel extends Service implements NeoPixelControl {
 
   @Override
   public void detach(String controllerName) {
-    // TODO Auto-generated method stub
-
+	  detach((NeoPixelController) Runtime.getService(controllerName));
   }
 
   @Override

--- a/src/main/java/org/myrobotlab/service/NeoPixel.java
+++ b/src/main/java/org/myrobotlab/service/NeoPixel.java
@@ -54,18 +54,22 @@ public class NeoPixel extends Service implements NeoPixelControl {
 
   transient NeoPixelController controller;
 
+  public Integer depth = 0;
+  
   public static class PixelColor {
     public int address;
     public int red;
     public int blue;
     public int green;
+    public int white;
     public boolean changed;
 
-    PixelColor(int address, int red, int green, int blue) {
+    PixelColor(int address, int red, int green, int blue, int white) {
       this.address = address;
       this.red = red;
       this.blue = blue;
       this.green = green;
+      this.white = white;
       changed = true;
     }
 
@@ -74,6 +78,7 @@ public class NeoPixel extends Service implements NeoPixelControl {
       red = 0;
       blue = 0;
       green = 0;
+      white = 0;
       changed = true;
     }
 
@@ -173,12 +178,19 @@ public class NeoPixel extends Service implements NeoPixelControl {
   }
 
   public void setPixel(int address, int red, int green, int blue) {
-    PixelColor pixel = new PixelColor(address, red, green, blue);
+    setPixel(address, red, green, blue, 0); 
+  }
+  
+  public void setPixel(int address, int red, int green, int blue, int white) {
+    PixelColor pixel = new PixelColor(address, red, green, blue, white);
     setPixel(pixel);
   }
-
   public void setPixel(String address, String red, String green, String blue) {
-    PixelColor pixel = new PixelColor(Integer.parseInt(address), Integer.parseInt(red), Integer.parseInt(green), Integer.parseInt(blue));
+    setPixel(address, red, green, blue, "0");
+  }
+  
+  public void setPixel(String address, String red, String green, String blue, String white) {
+    PixelColor pixel = new PixelColor(Integer.parseInt(address), Integer.parseInt(red), Integer.parseInt(green), Integer.parseInt(blue), Integer.parseInt(white));
     setPixel(pixel);
   }
 
@@ -213,12 +225,20 @@ public class NeoPixel extends Service implements NeoPixelControl {
   }
 
   public void sendPixel(int address, int red, int green, int blue) {
-    PixelColor pixel = new PixelColor(address, red, green, blue);
+    sendPixel(address, red, green, blue, 0);
+  }
+  
+  public void sendPixel(int address, int red, int green, int blue, int white) {
+    PixelColor pixel = new PixelColor(address, red, green, blue, white);
     sendPixel(pixel);
   }
 
   public void sendPixel(String address, String red, String green, String blue) {
-    PixelColor pixel = new PixelColor(Integer.parseInt(address), Integer.parseInt(red), Integer.parseInt(green), Integer.parseInt(blue));
+    sendPixel(address, red, green, blue, "0.0"); 
+  }
+  
+  public void sendPixel(String address, String red, String green, String blue,String white) {
+    PixelColor pixel = new PixelColor(Integer.parseInt(address), Integer.parseInt(red), Integer.parseInt(green), Integer.parseInt(blue), Integer.parseInt(white));
     sendPixel(pixel);
   }
 
@@ -261,7 +281,7 @@ public class NeoPixel extends Service implements NeoPixelControl {
 
   public void turnOff() {
     for (int i = 1; i <= numPixel; i++) {
-      PixelColor pixel = new PixelColor(i, 0, 0, 0);
+      PixelColor pixel = new PixelColor(i, 0, 0, 0, 0);
       setPixel(pixel);
     }
     animationStop();
@@ -302,7 +322,7 @@ public class NeoPixel extends Service implements NeoPixelControl {
 
     // create a new matrix
     for (int i = 1; i < numPixel + 1; i++) {
-      setPixel(new PixelColor(i, 0, 0, 0));
+      setPixel(new PixelColor(i, 0, 0, 0, 0));
     }
 
     controller.neoPixelAttach(this, pin, numPixel);
@@ -355,7 +375,7 @@ public class NeoPixel extends Service implements NeoPixelControl {
       // webgui.startBrowser("http://localhost:8888/#/service/neopixel");
       neopixel.attach(arduino, 6, 120);
       // sleep(50);
-      PixelColor pix = new NeoPixel.PixelColor(1, 255, 255, 0);
+      PixelColor pix = new NeoPixel.PixelColor(1, 255, 255, 0, 0);
       // neopixel.setPixel(pix);
       neopixel.sendPixel(pix);
       // neopixel.setAnimation(NEOPIXEL_ANIMATION_LARSON_SCANNER, 255, 0, 0, 1);

--- a/src/main/java/org/myrobotlab/swing/NeoPixelGui.java
+++ b/src/main/java/org/myrobotlab/swing/NeoPixelGui.java
@@ -186,10 +186,10 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
       if (attachButton.getText().equals(attach)) {
         int index = controller.getSelectedIndex();
         if (index != -1) {
-          swingGui.send(boundServiceName, attach, controller.getSelectedItem(), pinList.getSelectedItem(), pixelList.getSelectedItem(), deviceList.getSelectedItem().getId());
+          swingGui.send(boundServiceName, attach, controller.getSelectedItem(), pinList.getSelectedItem(), pixelList.getSelectedItem());
         }
       } else {
-        swingGui.send(boundServiceName, detach);
+        swingGui.send(boundServiceName, detach, controller.getSelectedItem());
       }
     }
     if (o == sendPixelMatrix) {

--- a/src/main/java/org/myrobotlab/swing/NeoPixelGui.java
+++ b/src/main/java/org/myrobotlab/swing/NeoPixelGui.java
@@ -53,7 +53,7 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
   String detach = "detach";
   JButton attachButton = new JButton(attach);
 
-  JComboBox<Item> deviceList = new JComboBox<Item>();
+  JComboBox<String> deviceList = new JComboBox<String>();
   JComboBox<String> controller = new JComboBox<String>();
   JComboBox<String> pinList = new JComboBox<String>();
   JComboBox<String> pixelList = new JComboBox<String>();
@@ -69,6 +69,7 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
   JTextField[] pixelRed = new JTextField[25];
   JTextField[] pixelGreen = new JTextField[25];
   JTextField[] pixelBlue = new JTextField[25];
+  JTextField[] pixelWhite = new JTextField[25];
 
   JButton[] setPixel = new JButton[25];
   JButton[] sendPixel = new JButton[25];
@@ -147,6 +148,7 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
     line.add(new JLabel("Red"));
     line.add(new JLabel("Green"));
     line.add(new JLabel("Blue"));
+    line.add(new JLabel("White"));
     center.add(line);
     for (int i = 0; i < 25; i++) {
       JPanel line1 = new JPanel();
@@ -158,6 +160,8 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
       line1.add(pixelGreen[i]);
       pixelBlue[i] = new JTextField(3);
       line1.add(pixelBlue[i]);
+      pixelWhite[i] = new JTextField(3);
+      line1.add(pixelWhite[i]);
       setPixel[i] = new JButton("Set Pixel");
       setPixel[i].addActionListener(this);
       sendPixel[i] = new JButton("Send Pixel");
@@ -186,7 +190,7 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
       if (attachButton.getText().equals(attach)) {
         int index = controller.getSelectedIndex();
         if (index != -1) {
-          swingGui.send(boundServiceName, attach, controller.getSelectedItem(), pinList.getSelectedItem(), pixelList.getSelectedItem());
+          swingGui.send(boundServiceName, attach, controller.getSelectedItem(), pinList.getSelectedItem(), pixelList.getSelectedItem(), deviceList.getSelectedItem());
         }
       } else {
         swingGui.send(boundServiceName, detach, controller.getSelectedItem());
@@ -206,10 +210,10 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
     }
     for (int i = 0; i < 25; i++) {
       if (o == setPixel[i]) {
-        swingGui.send(boundServiceName, "setPixel", pixelAddress[i].getText(), pixelRed[i].getText(), pixelGreen[i].getText(), pixelBlue[i].getText());
+        swingGui.send(boundServiceName, "setPixel", pixelAddress[i].getText(), pixelRed[i].getText(), pixelGreen[i].getText(), pixelBlue[i].getText(), pixelWhite[i].getText());
       }
       if (o == sendPixel[i]) {
-        swingGui.send(boundServiceName, "sendPixel", pixelAddress[i].getText(), pixelRed[i].getText(), pixelGreen[i].getText(), pixelBlue[i].getText());
+        swingGui.send(boundServiceName, "sendPixel", pixelAddress[i].getText(), pixelRed[i].getText(), pixelGreen[i].getText(), pixelBlue[i].getText(), pixelWhite[i].getText());
       }
     }
     if (o == animationList) {
@@ -231,19 +235,22 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
   public void onState(NeoPixel neopixel) {
 
     refreshControllers();
+    boolean isAttached = neopixel.isAttached();
+    deviceList.setEnabled(!isAttached);
     controller.setSelectedItem(neopixel.getControllerName());
+    controller.setEnabled(!isAttached);
     pinList.setSelectedItem(neopixel.pin);
+    pinList.setEnabled(!isAttached);
     pixelList.setSelectedItem(neopixel.numPixel.toString());
+    pixelList.setEnabled(!isAttached);
+    refresh.setEnabled(isAttached);
+    turnOnOff.setEnabled(isAttached);
     animStart.setEnabled(neopixel.isAttached());
-    if (neopixel.isAttached()) {
+    if (isAttached) {
       animColor.setVisible(neopixel.animationSettingColor);
       labelSpeed.setVisible(neopixel.animationSettingSpeed);
       animSpeed.setVisible(neopixel.animationSettingSpeed);
       attachButton.setText(detach);
-      controller.setEnabled(false);
-      pinList.setEnabled(false);
-      pixelList.setEnabled(false);
-      refresh.setEnabled(true);
       animation.setText(neopixel.animation);
       animationList.setEnabled(true);
       for (int i = 0; i < neopixel.savedPixelMatrix.size() && neopixel.savedPixelMatrix.size() > 0; i++) {
@@ -251,6 +258,7 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
         pixelRed[i].setVisible(true);
         pixelGreen[i].setVisible(true);
         pixelBlue[i].setVisible(true);
+        pixelWhite[i].setVisible(true);
         setPixel[i].setVisible(true);
         sendPixel[i].setVisible(true);
         try {
@@ -258,12 +266,11 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
           pixelRed[i].setText(neopixel.savedPixelMatrix.get(i).red + "");
           pixelGreen[i].setText(neopixel.savedPixelMatrix.get(i).green + "");
           pixelBlue[i].setText(neopixel.savedPixelMatrix.get(i).blue + "");
-
+          pixelWhite[i].setText(neopixel.savedPixelMatrix.get(i).white + "");
         } catch (Exception e) {
           log.warn("neopixel {} savedPixelMatrix InvocationTargetException", neopixel.getName());
           log.debug("neopixel {} savedPixelMatrix InvocationTargetException : " + e, neopixel.getName());
         }
-
         setPixel[i].setEnabled(true);
         sendPixel[i].setEnabled(true);
       }
@@ -272,27 +279,22 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
         pixelRed[i].setVisible(false);
         pixelGreen[i].setVisible(false);
         pixelBlue[i].setVisible(false);
+        pixelWhite[i].setVisible(false);
         setPixel[i].setVisible(false);
         sendPixel[i].setVisible(false);
       }
       sendPixelMatrix.setEnabled(true);
-      turnOnOff.setEnabled(true);
     } else {
       animColor.setVisible(false);
       labelSpeed.setVisible(neopixel.animationSettingSpeed);
       animSpeed.setVisible(neopixel.animationSettingSpeed);
       attachButton.setText(attach);
-      controller.setEnabled(true);
-      pinList.setEnabled(true);
-      pixelList.setEnabled(true);
-      refresh.setEnabled(false);
       animationList.setEnabled(false);
       for (int i = 0; i < 25; i++) {
         setPixel[i].setEnabled(false);
         sendPixel[i].setEnabled(false);
       }
       sendPixelMatrix.setEnabled(false);
-      turnOnOff.setEnabled(false);
     }
     if (neopixel.off) {
       turnOnOff.setText("Turn On");
@@ -309,8 +311,8 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
   }
 
   public void getDeviceList() {
-	  deviceList.addItem(new Item(3, "RGB")); // 3 channels (24bit)
-	  deviceList.addItem(new Item(4, "RGBW")); // 4 channels (32bit)
+	  deviceList.addItem("RGB"); // 3 channels (24bit)
+	  deviceList.addItem("RGBW"); // 4 channels (32bit)
   }
   
   public void getPinList() {
@@ -339,29 +341,5 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
         controller.setSelectedItem(boundService.getControllerName());
       }
     });
-  }
-  
-  private class Item {
-
-	private int id;
-	private String description;
-
-	public Item(int id, String description) {
-	  this.id = id;
-	  this.description = description;
-	}
-
-	public int getId() {
-	  return id;
-	}
-
-	public String getDescription() {
-	  return description;
-	}
-
-	@Override
-	public String toString() {
-	  return description;
-	}
   }
 }

--- a/src/main/java/org/myrobotlab/swing/NeoPixelGui.java
+++ b/src/main/java/org/myrobotlab/swing/NeoPixelGui.java
@@ -53,10 +53,12 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
   String detach = "detach";
   JButton attachButton = new JButton(attach);
 
+  JComboBox<Item> deviceList = new JComboBox<Item>();
   JComboBox<String> controller = new JComboBox<String>();
   JComboBox<String> pinList = new JComboBox<String>();
   JComboBox<String> pixelList = new JComboBox<String>();
 
+  JLabel deviceLabel = new JLabel("Device");
   JLabel controllerLabel = new JLabel("Controller");
   JLabel pinLabel = new JLabel("Pin");
   JLabel pixelLabel = new JLabel("Num. Pixel");
@@ -97,6 +99,8 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
 
     display.setLayout(new BorderLayout());
     JPanel north = new JPanel();
+    north.add(deviceLabel);
+    north.add(deviceList);
     north.add(controllerLabel);
     north.add(controller);
     north.add(pinLabel);
@@ -164,6 +168,7 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
     }
     display.add(center, BorderLayout.CENTER);
     display.add(anim, BorderLayout.SOUTH);
+    getDeviceList();
     getPinList();
     getPixelList();
     getAnimationList();
@@ -181,7 +186,7 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
       if (attachButton.getText().equals(attach)) {
         int index = controller.getSelectedIndex();
         if (index != -1) {
-          swingGui.send(boundServiceName, attach, controller.getSelectedItem(), pinList.getSelectedItem(), pixelList.getSelectedItem());
+          swingGui.send(boundServiceName, attach, controller.getSelectedItem(), pinList.getSelectedItem(), pixelList.getSelectedItem(), deviceList.getSelectedItem().getId());
         }
       } else {
         swingGui.send(boundServiceName, detach);
@@ -303,6 +308,11 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
     }
   }
 
+  public void getDeviceList() {
+	  deviceList.addItem(new Item(3, "RGB")); // 3 channels (24bit)
+	  deviceList.addItem(new Item(4, "RGBW")); // 4 channels (32bit)
+  }
+  
   public void getPinList() {
     for (int i = 0; i < 70; i++) {
       pinList.addItem(String.format("%d", i));
@@ -329,5 +339,29 @@ public class NeoPixelGui extends ServiceGui implements ActionListener {
         controller.setSelectedItem(boundService.getControllerName());
       }
     });
+  }
+  
+  private class Item {
+
+	private int id;
+	private String description;
+
+	public Item(int id, String description) {
+	  this.id = id;
+	  this.description = description;
+	}
+
+	public int getId() {
+	  return id;
+	}
+
+	public String getDescription() {
+	  return description;
+	}
+
+	@Override
+	public String toString() {
+	  return description;
+	}
   }
 }

--- a/src/main/resources/resource/Arduino/MrlComm/ArduinoMsgCodec.h
+++ b/src/main/resources/resource/Arduino/MrlComm/ArduinoMsgCodec.h
@@ -9,7 +9,7 @@
  * 							src\resource\Arduino\generate\ArduinoMsgCodec.template.h
  */
 
-#define MRLCOMM_VERSION			66
+#define MRLCOMM_VERSION			67
 #define MAGIC_NUMBER            170 // 10101010
 #define MAX_MSG_SIZE			64
 
@@ -63,7 +63,7 @@
 #define I2C_WRITE_READ 18
 // < publishI2cData/deviceId/[] data
 #define PUBLISH_I2C_DATA 19
-// > neoPixelAttach/deviceId/pin/b32 numPixels
+// > neoPixelAttach/deviceId/pin/b32 numPixels/depth
 #define NEO_PIXEL_ATTACH 20
 // > neoPixelSetAnimation/deviceId/animation/red/green/blue/b16 speed
 #define NEO_PIXEL_SET_ANIMATION 21

--- a/src/main/resources/resource/Arduino/MrlComm/MrlComm.cpp
+++ b/src/main/resources/resource/Arduino/MrlComm/MrlComm.cpp
@@ -332,13 +332,13 @@ void MrlComm::i2cWriteRead(byte deviceId, byte deviceAddress, byte readSize, byt
 }
 
 // > neoPixelAttach/pin/b16 numPixels
-void MrlComm::neoPixelAttach(byte deviceId, byte pin, long numPixels)
+void MrlComm::neoPixelAttach(byte deviceId, byte pin, long numPixels, byte depth)
 {
 	//msg->publishDebug("MrlNeopixel.deviceAttach!");
 
 	MrlNeopixel *neo = (MrlNeopixel *)addDevice(new MrlNeopixel(deviceId));
 	msg->publishDebug("id" + String(deviceId));
-	neo->attach(pin, numPixels);
+	neo->attach(pin, numPixels, depth);
 }
 
 // > neoPixelAttach/pin/b16 numPixels

--- a/src/main/resources/resource/Arduino/MrlComm/MrlComm.h
+++ b/src/main/resources/resource/Arduino/MrlComm/MrlComm.h
@@ -108,8 +108,8 @@ public:
   void i2cWrite( byte deviceId,  byte deviceAddress,  byte dataSize, const byte*data);
   // > i2cWriteRead/deviceId/deviceAddress/readSize/writeValue
   void i2cWriteRead( byte deviceId,  byte deviceAddress,  byte readSize,  byte writeValue);
-  // > neoPixelAttach/deviceId/pin/b32 numPixels
-  void neoPixelAttach( byte deviceId,  byte pin,  long numPixels);
+  // > neoPixelAttach/deviceId/pin/b32 numPixels/depth
+  void neoPixelAttach( byte deviceId,  byte pin,  long numPixels,  byte depth);
   // > neoPixelSetAnimation/deviceId/animation/red/green/blue/b16 speed
   void neoPixelSetAnimation( byte deviceId,  byte animation,  byte red,  byte green,  byte blue,  int speed);
   // > neoPixelWriteMatrix/deviceId/[] buffer

--- a/src/main/resources/resource/Arduino/MrlComm/MrlNeopixel.cpp
+++ b/src/main/resources/resource/Arduino/MrlComm/MrlNeopixel.cpp
@@ -11,6 +11,7 @@ void Pixel::clearPixel() {
 	red = 0;
 	blue = 0;
 	green = 0;
+  white = 0;
 }
 
 void Pixel::setPixel(unsigned char red, unsigned char green,
@@ -34,7 +35,7 @@ MrlNeopixel::~MrlNeopixel() {
 	delete pixels;
 }
 
-bool MrlNeopixel::attach(byte pin, long numPixels) {
+bool MrlNeopixel::attach(byte pin, long numPixels, byte depth) {
   // msg->publishDebug("MrlNeopixel.deviceAttach !" + String(pin));
 	pixels = new Pixel[numPixels + 1];
 	//if (BOARD == BOARD_TYPE_ID_UNKNOWN) { // REALLY ? WHY ?
@@ -43,6 +44,7 @@ bool MrlNeopixel::attach(byte pin, long numPixels) {
 	//}
  this->pin = pin;
  this->numPixel = numPixels;
+ this->depth = depth;
 	state = 1;
 	bitmask = digitalPinToBitMask(pin);
 	pinMode(pin, OUTPUT);
@@ -579,6 +581,9 @@ inline void MrlNeopixel::sendPixel(Pixel p) {
 	sendByte(p.green); // Neopixel wants colors in green then red then blue order
 	sendByte(p.red);
 	sendByte(p.blue);
+  if (depth == 4) {
+    sendByte(p.white);
+  }
 }
 
 void MrlNeopixel::show() {

--- a/src/main/resources/resource/Arduino/MrlComm/MrlNeopixel.h
+++ b/src/main/resources/resource/Arduino/MrlComm/MrlNeopixel.h
@@ -65,6 +65,8 @@ struct Pixel{
   unsigned char red;
   unsigned char blue;
   unsigned char green;
+  unsigned char white;
+  byte depth;
   Pixel();
   void clearPixel();
   void setPixel(unsigned char red, unsigned char green, unsigned char blue);
@@ -89,10 +91,11 @@ class MrlNeopixel:public Device{
     int _dir;
     int _step;
     unsigned char _alpha;
+    byte depth;
   public:
   MrlNeopixel(int deviceId);
   ~MrlNeopixel();
-  bool attach(byte pin, long numPixels);
+  bool attach(byte pin, long numPixels, byte depth);
 #ifndef ESP8266
   inline void sendBitB(bool bitVal);
   inline void sendBitC(bool bitVal);

--- a/src/main/resources/resource/Arduino/MrlComm/Msg.cpp
+++ b/src/main/resources/resource/Arduino/MrlComm/Msg.cpp
@@ -84,8 +84,8 @@ Msg* Msg::getInstance() {
   void i2cWrite( byte deviceId,  byte deviceAddress,  byte dataSize, const byte*data);
   // > i2cWriteRead/deviceId/deviceAddress/readSize/writeValue
   void i2cWriteRead( byte deviceId,  byte deviceAddress,  byte readSize,  byte writeValue);
-  // > neoPixelAttach/deviceId/pin/b32 numPixels
-  void neoPixelAttach( byte deviceId,  byte pin,  long numPixels);
+  // > neoPixelAttach/deviceId/pin/b32 numPixels/depth
+  void neoPixelAttach( byte deviceId,  byte pin,  long numPixels,  byte depth);
   // > neoPixelSetAnimation/deviceId/animation/red/green/blue/b16 speed
   void neoPixelSetAnimation( byte deviceId,  byte animation,  byte red,  byte green,  byte blue,  int speed);
   // > neoPixelWriteMatrix/deviceId/[] buffer
@@ -387,7 +387,9 @@ void Msg::processCommand() {
       startPos += 1;
       long numPixels = b32(ioCmd, startPos+1);
       startPos += 4; //b32
-      mrlComm->neoPixelAttach( deviceId,  pin,  numPixels);
+      byte depth = ioCmd[startPos+1]; // bu8
+      startPos += 1;
+      mrlComm->neoPixelAttach( deviceId,  pin,  numPixels,  depth);
       break;
 	}
   case NEO_PIXEL_SET_ANIMATION: { // neoPixelSetAnimation

--- a/src/main/resources/resource/Arduino/generate/arduinoMsgs.schema
+++ b/src/main/resources/resource/Arduino/generate/arduinoMsgs.schema
@@ -71,7 +71,7 @@
 < publishI2cData/deviceId/[] data
 
 # NeoPixel
-> neoPixelAttach/deviceId/pin/b32 numPixels
+> neoPixelAttach/deviceId/pin/b32 numPixels/depth
 > neoPixelSetAnimation/deviceId/animation/red/green/blue/b16 speed
 > neoPixelWriteMatrix/deviceId/[] buffer
 

--- a/src/test/java/org/myrobotlab/service/NeoPixelTest.java
+++ b/src/test/java/org/myrobotlab/service/NeoPixelTest.java
@@ -57,7 +57,7 @@ public class NeoPixelTest extends AbstractTest {
   @Test
   public void testSendPixelIntIntIntInt() {
     neopixel.sendPixel(2, 0, 255, 0);
-    assertTrue(neopixel.pixelMatrix.get(2).isEqual(new NeoPixel.PixelColor(2, 0, 255, 0)));
+    assertTrue(neopixel.pixelMatrix.get(2).isEqual(new NeoPixel.PixelColor(2, 0, 255, 0, 0)));
   }
 
   /**
@@ -76,7 +76,7 @@ public class NeoPixelTest extends AbstractTest {
   @Test
   public void testSetPixelIntIntIntInt() {
     neopixel.setPixel(2, 255, 0, 0);
-    assertTrue(neopixel.pixelMatrix.get(2).isEqual(new NeoPixel.PixelColor(2, 255, 0, 0)));
+    assertTrue(neopixel.pixelMatrix.get(2).isEqual(new NeoPixel.PixelColor(2, 255, 0, 0, 0)));
   }
 
   /**
@@ -85,7 +85,7 @@ public class NeoPixelTest extends AbstractTest {
   @Test
   public void testTurnOff() {
     neopixel.turnOff();
-    assertTrue(neopixel.pixelMatrix.get(2).isEqual(new NeoPixel.PixelColor(2, 0, 0, 0)));
+    assertTrue(neopixel.pixelMatrix.get(2).isEqual(new NeoPixel.PixelColor(2, 0, 0, 0, 0)));
     neopixel.turnOn();
   }
 


### PR DESCRIPTION
Added support for 4 channel colour depth (RGBW) neopixels devices.

The attach function has been changed to have a new parameter for depth (colour depth). Then the MRLComm sketch has been updated to either send 3 channels (24bit) or 4 channels (32bit) of colour data to the neopixel depending upon the value of depth.

The swing gui has been updated to allow the user to select either RGB or RGBW device type.

The detach function was not working from the swing gui. This branch also fixes that issue.