### PR TITLE
routing fixes

### DIFF
--- a/src/main/java/org/myrobotlab/net/RouteTable.java
+++ b/src/main/java/org/myrobotlab/net/RouteTable.java
@@ -10,12 +10,13 @@ import org.myrobotlab.service.Runtime;
 import org.slf4j.Logger;
 
 public class RouteTable {
-  
+
   public final static Logger log = LoggerFactory.getLogger(Runtime.class);
 
   protected RouteEntry defaultRoute = null;
 
   protected Map<String, RouteEntry> routes = new HashMap<>();
+  protected Map<String, String> localGatewayKeysToUuid = new HashMap<>();
 
   public void addRoute(String destination, String uuid, int metric) {
     if (routes.containsKey(destination)) {
@@ -23,16 +24,15 @@ public class RouteTable {
     }
     RouteEntry r = new RouteEntry(destination, uuid, metric);
     /*
-    if (defaultRoute == null || r.metric < defaultRoute.metric) {
-      defaultRoute = r;
-    }
-    */
+     * if (defaultRoute == null || r.metric < defaultRoute.metric) {
+     * defaultRoute = r; }
+     */
     // "latest" route strategy
     log.info("adding route and setting default to {}", r);
     routes.put(destination, r);
     defaultRoute = r;
   }
-  
+
   public boolean contains(String id) {
     return routes.containsKey(id);
   }
@@ -50,6 +50,7 @@ public class RouteTable {
 
   /**
    * Thread safe removal of routes
+   * 
    * @param uuid
    */
   public void removeRoute(String uuid) {
@@ -58,7 +59,7 @@ public class RouteTable {
       if (!uuid.equals(r.uuid)) {
         newTable.put(r.destination, r);
       }
-    }    
+    }
     routes = newTable;
   }
 
@@ -70,5 +71,18 @@ public class RouteTable {
       }
     }
     return ids;
+  }
+
+  public void addLocalGatewayKey(String localGatewayKey, String uuid) {
+    localGatewayKeysToUuid.put(localGatewayKey, uuid);
+
+  }
+
+  public String getConnectionUuid(String localGatewayKey) {
+    return localGatewayKeysToUuid.get(localGatewayKey);
+  }
+
+  public String remove(String localGatewayKey) {
+    return localGatewayKeysToUuid.remove(localGatewayKey);
   }
 }

--- a/src/main/java/org/myrobotlab/process/InProcessCli.java
+++ b/src/main/java/org/myrobotlab/process/InProcessCli.java
@@ -440,7 +440,7 @@ public class InProcessCli implements Runnable {
             }
           }
         } else {
-          if ("onStdOut".equals(msg.getMethod()) || "onStdError".equals(msg.getMethod())) {
+          if ("json".equals(msg.encoding) || "onStdOut".equals(msg.getMethod()) || "onStdError".equals(msg.getMethod())) {
             // python interpreter
             try {
               out.write(o.toString().getBytes());
@@ -448,7 +448,7 @@ public class InProcessCli implements Runnable {
               log.error("write threw", e);
             }
           } else {
-            writeToJson(o);
+              writeToJson(o);
           }
         }
       }

--- a/src/main/resources/resource/WebGui/app/service/js/MqttBrokerGui.js
+++ b/src/main/resources/resource/WebGui/app/service/js/MqttBrokerGui.js
@@ -12,12 +12,9 @@ angular.module('mrlapp.service.MqttBrokerGui', []).controller('MqttBrokerGuiCtrl
     $scope.reverse = true
 
     $scope.start = function() {
-        if ($scope.service.username) {
-            msg.send('setUsername', $scope.service.username)
-        }
-        if ($scope.service.password) {
-            msg.send('setPassword', $scope.service.password)
-        }
+
+        msg.send('setUsername', $scope.service.username)
+        msg.send('setPassword', $scope.service.password)
         msg.send('setAddress', $scope.service.address)
         msg.send('setMqttPort', $scope.service.mqttPort)
         msg.send('setWsPort', $scope.service.wsPort)


### PR DESCRIPTION
1. ProcessCli will not encode into json - if already encoded (was double encoding previously)
2. RouteTable - added localGatewayKeysToUuid for clarity - a gateway needs a key to pull back the connection/channel
                for sendRemote message
3. Mqtt -   unique inbound channel subscribed to on connection 
            String rxTopic = String.format("mrl/gw/%s/rx<-%s", getFullName(), remoteFullName);
4. Mqtt - addLocalGatewayKey added for a callback to get the connection/channel 
5. Mqtt -   if route table entry for incoming msg messageArrive(msg) does not have a route in the route table
            one is added
6. Mqtt - when sending remotely, get a remote id, use it to get a route, you the route to get a connection - send message
7. MqttBroker - cleaned up listen for most complex to least complex