### PR TITLE
fixed some service lifecyel and inmoov2 autodisable

### DIFF
--- a/src/main/java/org/myrobotlab/framework/Service.java
+++ b/src/main/java/org/myrobotlab/framework/Service.java
@@ -1854,9 +1854,9 @@ public abstract class Service implements Runnable, Serializable, ServiceInterfac
       isRunning = true;
       Runtime runtime = Runtime.getInstance();
       if (runtime != null) {
-        runtime.broadcast("started", name);
+        runtime.broadcast("started", getFullName());
       }
-
+      
     } else {
       log.debug("startService request: service {} is already running", name);
     }
@@ -2652,22 +2652,22 @@ public abstract class Service implements Runnable, Serializable, ServiceInterfac
   }
 
   @Override
-  public void onCreated(String serviceName) {
+  public void onCreated(String fullname) {
     // service life-cycle callback - override if interested in these events
   }
 
   @Override
-  public void onStarted(String serviceName) {
+  public void onStarted(String fullname) {
     // service life-cycle callback - override if interested in these events
   }
 
   @Override
-  public void onStopped(String serviceName) {
+  public void onStopped(String fullname) {
     // service life-cycle callback - override if interested in these events
   }
 
   @Override
-  public void onReleased(String serviceName) {
+  public void onReleased(String fullname) {
     // service life-cycle callback - override if interested in these events
   }
 

--- a/src/main/java/org/myrobotlab/framework/Service.java
+++ b/src/main/java/org/myrobotlab/framework/Service.java
@@ -1946,7 +1946,7 @@ public abstract class Service implements Runnable, Serializable, ServiceInterfac
     thisThread = null;
 
     Runtime runtime = Runtime.getInstance();
-    runtime.broadcast("stopped", getName());
+    runtime.broadcast("stopped", getFullName());
     // save(); removed by GroG
   }
 

--- a/src/main/java/org/myrobotlab/service/InMoov2.java
+++ b/src/main/java/org/myrobotlab/service/InMoov2.java
@@ -45,8 +45,6 @@ public class InMoov2 extends Service implements TextListener, TextPublisher, Joy
   static boolean RobotCanMoveRandom = true;
   private static final long serialVersionUID = 1L;
 
-  public Arduino neopixelArduino = null;
-
   static String speechRecognizer = "WebkitSpeechRecognition";
 
   /**
@@ -63,6 +61,29 @@ public class InMoov2 extends Service implements TextListener, TextPublisher, Joy
       error("unable to execute script %s", someScriptName);
     }
   }
+  
+  
+  /**
+   * Part of service life cycle - a new servo has been started
+   */
+  public void onStarted(String fullname) {
+    log.info("{} started");
+    try {
+      ServiceInterface si = Runtime.getService(fullname);
+      if ("Servo".equals(si.getSimpleName())){
+        log.info("sending setAutoDisable true to {}", fullname);
+        send(fullname, "setAutoDisable", true);
+        // ServoControl sc = (ServoControl)Runtime.getService(name);
+      }
+    } catch (Exception e) {
+      log.error("onStarted threw", e);
+    }
+  }
+  
+  public void onCreated(String fullname) {
+    log.info("{} created", fullname);
+  }
+
 
   /**
    * This method will load a python file into the python interpreter.
@@ -99,9 +120,10 @@ public class InMoov2 extends Service implements TextListener, TextPublisher, Joy
 
       LoggingFactory.init(Level.INFO);
       Platform.setVirtual(true);
-      Runtime.main(new String[] { "--interactive", "--id", "inmoov" });
-
+      Runtime.main(new String[] { "--from-launcher", "--id", "inmoov" });
+      Runtime.start("s01", "Servo");
       InMoov2 i01 = (InMoov2) Runtime.start("i01", "InMoov2");
+      Runtime.start("s02", "Servo");
 
       WebGui webgui = (WebGui) Runtime.create("webgui", "WebGui");
       webgui.autoStartBrowser(false);
@@ -266,6 +288,17 @@ public class InMoov2 extends Service implements TextListener, TextPublisher, Joy
     // by default all servos will auto-disable
     // Servo.setAutoDisableDefault(true); //until peer servo services for
     // InMoov2 have the auto disable behavior, we should keep this
+    
+    // same as created in runtime - send asyc message to all
+    // registered services, this service has started
+    // find all servos - set them all to autoDisable(true)
+    // onStarted(name) will handle all future created servos
+    List<ServiceInterface> services = Runtime.getServices();
+    for (ServiceInterface si : services) {
+      if ("Servo".equals(si.getSimpleName())) {
+        send(si.getFullName(), "setAutoDisable", true);
+      }
+    } 
 
     locales = Locale.getLocaleMap("en-US", "fr-FR", "es-ES", "de-DE", "nl-NL", "ru-RU", "hi-IN", "it-IT", "fi-FI", "pt-PT", "tr-TR");
     locale = Runtime.getInstance().getLocale();
@@ -1070,7 +1103,7 @@ public class InMoov2 extends Service implements TextListener, TextPublisher, Joy
   }
 
   public void setNeopixelAnimation(String animation, Integer red, Integer green, Integer blue, Integer speed) {
-    if (neopixel != null /* && neopixelArduino != null */) {
+    if (neopixel != null) {
       neopixel.setAnimation(animation, red, green, blue, speed);
     } else {
       warn("No Neopixel attached");
@@ -2012,7 +2045,7 @@ public class InMoov2 extends Service implements TextListener, TextPublisher, Joy
   }
 
   public void stopNeopixelAnimation() {
-    if (neopixel != null && neopixelArduino != null) {
+    if (neopixel != null) {
       neopixel.animationStop();
     } else {
       warn("No Neopixel attached");
@@ -2046,4 +2079,27 @@ public class InMoov2 extends Service implements TextListener, TextPublisher, Joy
     }
   }
 
+  public NeoPixel startNeopixel() {
+    return startNeopixel(getName() + ".right", 2, 16);
+  }
+
+  public NeoPixel startNeopixel(String controllerName) {
+    return startNeopixel(controllerName, 2, 16);
+  }
+
+  public NeoPixel startNeopixel(String controllerName, int pin, int numPixel) {
+
+    if (neopixel == null) {
+      try {
+        neopixel = (NeoPixel) startPeer("neopixel");
+        speakBlocking(get("STARTINGNEOPIXEL"));
+        // FIXME - lame use peers
+        isNeopixelActivated = true;
+        neopixel.attach(Runtime.getService(controllerName));
+      } catch (Exception e) {
+        error(e);
+      }
+    }
+    return neopixel;
+  }
 }

--- a/src/main/java/org/myrobotlab/service/Runtime.java
+++ b/src/main/java/org/myrobotlab/service/Runtime.java
@@ -426,7 +426,7 @@ public class Runtime extends Service implements MessageListener, ServiceLifeCycl
 
       if (runtime != null) {
 
-        runtime.broadcast("created", name);
+        runtime.broadcast("created", getFullName(name));
 
         // add all the service life cycle subscriptions
         runtime.addListener("registered", name);
@@ -437,12 +437,16 @@ public class Runtime extends Service implements MessageListener, ServiceLifeCycl
       }
 
       // initialization of the new service - it gets local registery events
-      // for pre-existing registered? created/started
+      // for pre-existing registered? created/started - NO !!!
+      // The new service is responsible for asking the registry for existing services on its creation
+      // this should not be done automatically
+      /*
       List<ServiceInterface> services = getServices();// getLocalServices();
       for (ServiceInterface s : services) {
         if (runtime != null && runtime.serviceData != null) {
           try {
             si.onRegistered(new Registration(s));
+            runtime.send(s.getName(), "onCreated", si.getFullName());
           } catch (Exception e) {
             runtime.error(String.format("onRegistered threw processing %s.onRegistered(%s)", s.getName(), name));
           }
@@ -450,12 +454,9 @@ public class Runtime extends Service implements MessageListener, ServiceLifeCycl
         // don't register or create or start event self
         if (s.getName().equals(si.getName())) {
           continue;
-        }
-        si.onCreated(s.getName());
-        if (si.isRunning()) {
-          si.onStarted(s.getName());
-        }
+        }        
       }
+      */
 
       return (Service) newService;
     } catch (Exception e) {

--- a/src/main/java/org/myrobotlab/service/TestCatcher.java
+++ b/src/main/java/org/myrobotlab/service/TestCatcher.java
@@ -457,11 +457,13 @@ public class TestCatcher extends Service implements SerialDataListener, HttpData
 
   public void onRegistered(Registration registration) {
     if (onRegistered != null) {
-      onRegistered.put(registration.getName(), registration);
+      onRegistered.put(registration.getFullName(), registration);
     }
   }
 
   public void onStarted(String serviceName) {
+    String info = String.format("notified --> %s  %s has started", getName(), serviceName);
+    log.info(info);
     onStarted.add(serviceName);
   }
 

--- a/src/main/java/org/myrobotlab/service/interfaces/ServiceLifeCycleListener.java
+++ b/src/main/java/org/myrobotlab/service/interfaces/ServiceLifeCycleListener.java
@@ -9,14 +9,14 @@ import org.myrobotlab.framework.Registration;
  */
 public interface ServiceLifeCycleListener {
 
-  public void onCreated(String serviceName);
+  public void onCreated(String fullname);
 
   public void onRegistered(Registration registration);
 
-  public void onStarted(String serviceName);
+  public void onStarted(String fullname);
 
-  public void onStopped(String serviceName);
+  public void onStopped(String fullname);
 
-  public void onReleased(String serviceName);
+  public void onReleased(String fullname);
 
 }

--- a/src/main/java/org/myrobotlab/service/meta/InMoov2Meta.java
+++ b/src/main/java/org/myrobotlab/service/meta/InMoov2Meta.java
@@ -59,6 +59,8 @@ public class InMoov2Meta extends MetaData {
     // Arduino"); NO !!!!
     addPeer("headTracking.x", "head.rothead", "Servo", "shared servo");
     addPeer("headTracking.y", "head.neck", "Servo", "shared servo");
+    
+    addPeer("neopixel", "NeoPixel", "neopixel animation");
 
     // Global - undecorated by self name
     // currently InMoov manually calls releasePeers - when it does


### PR DESCRIPTION
InMoov2 wants to setAutoDisable(true) on all servos - ones created before InMoov2 service and ones created after
This makes all servos past an present for the lifetime of InMoov2 to setAutoDisable(true)
They can manually be set back while InMoov2 is around - but it becomes the default for Servos in the service life-cycle
Also some service lifecycle cleanup