### PR TITLE
adding correct attach and supporting updates

### DIFF
--- a/src/main/java/org/myrobotlab/framework/Outbox.java
+++ b/src/main/java/org/myrobotlab/framework/Outbox.java
@@ -80,11 +80,15 @@ public class Outbox implements Runnable, Serializable {
     this.myService = myService;
   }
 
-  public Set<String> getAttached() {
+  public Set<String> getAttached(String publishingPoint) {    
     Set<String> unique = new TreeSet<>();
-    for (List<MRLListener> subcribers : notifyList.values()) {
+    for (List<MRLListener> subcribers : notifyList.values()) {      
       for (MRLListener listener : subcribers) {
-        unique.add(listener.callbackName);
+        if (publishingPoint == null) {
+            unique.add(listener.callbackName);
+        } else if (listener.topicMethod.equals(publishingPoint)) {
+            unique.add(listener.callbackName);
+        }
       }
     }
     return unique;
@@ -269,11 +273,12 @@ public class Outbox implements Runnable, Serializable {
         // ?
         ServiceInterface sw = Runtime.getService(msg.getName());
         if (sw == null) {
-          log.info("could not find service {} to process {} from sender {} - tearing down route", msg.getName(), msg.method, msg.sender);
+          log.debug("could not find service {} to process {} from sender {} - tearing down route", msg.getName(), msg.method, msg.sender);
+          /*
           ServiceInterface sender = Runtime.getService(msg.sender);
           if (sender != null) {
             sender.removeListener(msg.sendingMethod, msg.getName(), msg.method);
-          }
+          } */ // removed by GroG 20210523
           return;
         }
 

--- a/src/main/java/org/myrobotlab/framework/Service.java
+++ b/src/main/java/org/myrobotlab/framework/Service.java
@@ -190,7 +190,7 @@ public abstract class Service implements Runnable, Serializable, ServiceInterfac
   /**
    * order which this service was created
    */
-  Integer creationOrder;
+  int creationOrder = 0;
 
   // FIXME SecurityProvider
   protected AuthorizationProvider authProvider = null;
@@ -2224,8 +2224,18 @@ public abstract class Service implements Runnable, Serializable, ServiceInterfac
    */
   @Override
   public Set<String> getAttached() {
-    return outbox.getAttached();
+    // return all attached
+    return outbox.getAttached(null);
   }
+  
+  /**
+   * returns all currently attached services to a specific publishing point
+   */
+  @Override
+  public Set<String> getAttached(String publishPoint) {
+    return outbox.getAttached(publishPoint);
+  }
+
 
   /**
    * This attach when overriden "routes" to the appropriately typed
@@ -2691,6 +2701,21 @@ public abstract class Service implements Runnable, Serializable, ServiceInterfac
       return false;
     }
     return true;
+  }
+
+  @Override
+  public int compareTo(ServiceInterface o) {
+    if (this.creationOrder == o.getCreationOrder()) {
+      return 0;
+    }
+    if (this.creationOrder < o.getCreationOrder()) {
+      return -1;
+    }
+    return 1;
+  }
+
+  public int getCreationOrder() {
+    return creationOrder;
   }
 
 }

--- a/src/main/java/org/myrobotlab/framework/interfaces/Attachable.java
+++ b/src/main/java/org/myrobotlab/framework/interfaces/Attachable.java
@@ -86,6 +86,14 @@ public interface Attachable extends NameProvider {
    * @return the set of attached service names to this service
    */
   public Set<String> getAttached();
+  
+  /**
+   * get all attached to a specific publishing point/method
+   * 
+   * @param publishingPoint
+   * @return
+   */
+  public Set<String> getAttached(String publishingPoint);
 
   /**
    * @param instance

--- a/src/main/java/org/myrobotlab/framework/interfaces/ServiceInterface.java
+++ b/src/main/java/org/myrobotlab/framework/interfaces/ServiceInterface.java
@@ -4,15 +4,17 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.myrobotlab.framework.Inbox;
 import org.myrobotlab.framework.MRLListener;
 import org.myrobotlab.framework.MethodEntry;
 import org.myrobotlab.framework.Outbox;
+import org.myrobotlab.framework.Service;
 import org.myrobotlab.service.interfaces.ServiceLifeCycleListener;
 
 public interface ServiceInterface extends ServiceLifeCycleListener, ServiceQueue, LoggingSink, NameTypeProvider, MessageSubscriber, MessageSender, StateSaver, Invoker,
-    StatePublisher, StatusPublisher, ServiceStatus, Attachable {
+    StatePublisher, StatusPublisher, ServiceStatus, Attachable, Comparable<ServiceInterface> {
 
   /**
    * this is a local method which adds a request from some foreign service with
@@ -137,4 +139,6 @@ public interface ServiceInterface extends ServiceLifeCycleListener, ServiceQueue
 
   public void setLocale(String code);
 
+  public int getCreationOrder();
+  
 }

--- a/src/main/java/org/myrobotlab/i2c/I2CBus.java
+++ b/src/main/java/org/myrobotlab/i2c/I2CBus.java
@@ -195,4 +195,9 @@ public class I2CBus implements Attachable, I2CBusControl {
 
   }
 
+  @Override
+  public Set<String> getAttached(String publishingPoint) {
+    return getAttached();
+  }
+
 }

--- a/src/main/java/org/myrobotlab/sensor/TimeEncoder.java
+++ b/src/main/java/org/myrobotlab/sensor/TimeEncoder.java
@@ -455,4 +455,10 @@ public class TimeEncoder implements Runnable, EncoderControl {
     // TODO Auto-generated method stub
 
   }
+
+  @Override
+  public Set<String> getAttached(String publishingPoint) {
+    // TODO Auto-generated method stub
+    return null;
+  }
 }

--- a/src/main/java/org/myrobotlab/service/AzureTranslator.java
+++ b/src/main/java/org/myrobotlab/service/AzureTranslator.java
@@ -90,7 +90,7 @@ public class AzureTranslator extends Service implements TextListener, TextPublis
 
   @Override
   public void attachTextListener(TextListener service) {
-    addListener("publishText", service.getName());
+    attachTextListener(service.getName());
   }
 
   @Override
@@ -111,6 +111,11 @@ public class AzureTranslator extends Service implements TextListener, TextPublis
       return;
     }
     subscribe(service.getName(), "publishText");
+  }
+
+  @Override
+  public void attachTextListener(String name) {
+    addListener("publishText", name);
   }
 
 }

--- a/src/main/java/org/myrobotlab/service/GoogleSearch.java
+++ b/src/main/java/org/myrobotlab/service/GoogleSearch.java
@@ -267,8 +267,7 @@ public class GoogleSearch extends Service implements TextPublisher, SearchPublis
   @Override
   @Deprecated /* use standard attachTextListener */
   public void addTextListener(TextListener service) {
-    addListener("publishText", service.getName());
-
+    attachTextListener(service.getName());
   }
 
   @Override
@@ -279,7 +278,7 @@ public class GoogleSearch extends Service implements TextPublisher, SearchPublis
 
   @Override
   public void attachTextListener(TextListener service) {
-    addListener("publishText", service.getName());
+    attachTextListener(service.getName());
   }
 
   public static void main(String[] args) {
@@ -359,6 +358,11 @@ public class GoogleSearch extends Service implements TextPublisher, SearchPublis
   @Override
   public Map<String, Locale> getLocales() {
     return Locale.getAvailableLanguages();
+  }
+
+  @Override
+  public void attachTextListener(String name) {
+    addListener("publishText", name);
   }
 
 }

--- a/src/main/java/org/myrobotlab/service/HtmlFilter.java
+++ b/src/main/java/org/myrobotlab/service/HtmlFilter.java
@@ -125,7 +125,8 @@ public class HtmlFilter extends Service implements TextListener, TextPublisher {
       log.warn("{}.attachTextListener(null)");
       return;
     }
-    addListener("publishText", service.getName());
+    
+    attachTextListener(service.getName());
   }
 
   @Override
@@ -135,6 +136,11 @@ public class HtmlFilter extends Service implements TextListener, TextPublisher {
       return;
     }
     subscribe(service.getName(), "publishText");
+  }
+
+  @Override
+  public void attachTextListener(String name) {
+    addListener("publishText", name);
   }
 
 }

--- a/src/main/java/org/myrobotlab/service/InMoov2.java
+++ b/src/main/java/org/myrobotlab/service/InMoov2.java
@@ -329,7 +329,7 @@ public class InMoov2 extends Service implements TextListener, TextPublisher, Joy
 
   @Override
   public void attachTextListener(TextListener service) {
-    addListener("publishText", service.getName());
+    attachTextListener(service.getName());
   }
 
   public void attachTextPublisher(String name) {
@@ -2104,4 +2104,10 @@ public class InMoov2 extends Service implements TextListener, TextPublisher, Joy
     }
     return neopixel;
   }
+  
+  @Override
+  public void attachTextListener(String name) {
+    addListener("publishText", name);
+  }
+
 }

--- a/src/main/java/org/myrobotlab/service/ProgramAB.java
+++ b/src/main/java/org/myrobotlab/service/ProgramAB.java
@@ -167,10 +167,12 @@ public class ProgramAB extends Service implements TextListener, TextPublisher, L
     attachTextListener(service);
   }
 
+  @Deprecated /* use standard attachTextListener */
   public void addTextListener(SpeechSynthesis service) {
     addListener("publishText", service.getName(), "onText");
   }
 
+  @Deprecated /* use standard attachTextPublisher */
   public void addTextPublisher(TextPublisher service) {
     subscribe(service.getName(), "publishText");
   }
@@ -948,8 +950,14 @@ public class ProgramAB extends Service implements TextListener, TextPublisher, L
       log.warn("{}.attachTextListener(null)");
       return;
     }
-    addListener("publishText", service.getName());
+    attachTextListener(service.getName());
   }
+  
+  @Override
+  public void attachTextListener(String name) {
+    addListener("publishText", name);
+  }
+
 
   @Override
   public void attachTextPublisher(TextPublisher service) {

--- a/src/main/java/org/myrobotlab/service/Python.java
+++ b/src/main/java/org/myrobotlab/service/Python.java
@@ -811,7 +811,7 @@ public class Python extends Service {
       webgui.autoStartBrowser(false);
       webgui.startService();
       Python python = (Python) Runtime.start("python", "Python");
-      python.execFile("data/adafruit.py");
+      //python.execFile("data/adafruit.py");
       
       Runtime.start("i01", "InMoov2");
 

--- a/src/main/java/org/myrobotlab/service/Sphinx.java
+++ b/src/main/java/org/myrobotlab/service/Sphinx.java
@@ -631,4 +631,9 @@ public class Sphinx extends AbstractSpeechRecognizer {
     return Locale.getLocaleMap("en-US");
   }
 
+  @Override
+  public void attachTextListener(String name) {
+    addListener("publishText", name);
+  }
+
 }

--- a/src/main/java/org/myrobotlab/service/WebSocketConnector.java
+++ b/src/main/java/org/myrobotlab/service/WebSocketConnector.java
@@ -114,4 +114,10 @@ public class WebSocketConnector extends Service implements TextPublisher {
   public void attachTextListener(TextListener service) {
     addListener("publishText", service.getName());
   }
+
+  @Override
+  public void attachTextListener(String name) {
+    addListener("publishText", name);
+  }
+
 }

--- a/src/main/java/org/myrobotlab/service/WebkitSpeechRecognition.java
+++ b/src/main/java/org/myrobotlab/service/WebkitSpeechRecognition.java
@@ -90,5 +90,11 @@ public class WebkitSpeechRecognition extends AbstractSpeechRecognizer {
         "zh-cmn-Hant-TW", "zh-yue-Hant-HK", "zh-cmn-Hans-CN");
     return ret;
   }
+  
+  @Override
+  public void attachTextListener(String name) {
+    addListener("publishText", name);
+  }
+
 
 }

--- a/src/main/java/org/myrobotlab/service/WorkE.java
+++ b/src/main/java/org/myrobotlab/service/WorkE.java
@@ -811,8 +811,10 @@ public class WorkE extends Service implements StatusListener, TextPublisher, Spe
       log.error("worke no worky !", e);
     }
   }
-  /**
-   * </pre>
-   */
+
+  @Override
+  public void attachTextListener(String name) {
+    addListener("publishText", name);
+  }
 
 }

--- a/src/main/java/org/myrobotlab/service/interfaces/TextPublisher.java
+++ b/src/main/java/org/myrobotlab/service/interfaces/TextPublisher.java
@@ -11,4 +11,10 @@ public interface TextPublisher {
 
   public void attachTextListener(TextListener service);
 
+  /**
+   * the root for any other attachTextListener type
+   * @param name - the name of the text listener
+   */
+  public void attachTextListener(String name);
+
 }


### PR DESCRIPTION
Implemented attachTextPublish correctly
at the base it should be a pub/sub subscription with a string value, that is all that is needed.
A "service reference" should not be required.  This gives the benefit during runtime where one type of speech synthesis services named 'mouth' can be removed from ProgramAB and a new one brought up without any adverse affects.

It also means ProgramAB or other services which support attaching to Text Publishers can be pre-configured to publish to a named destination without NPEs