### PR TITLE
Grog config 2

### DIFF
--- a/src/main/java/org/myrobotlab/codec/CodecUtils.java
+++ b/src/main/java/org/myrobotlab/codec/CodecUtils.java
@@ -11,6 +11,9 @@ import java.io.OutputStream;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -21,9 +24,11 @@ import java.util.Set;
 
 import org.myrobotlab.framework.MRLListener;
 import org.myrobotlab.framework.Message;
+import org.myrobotlab.io.FileIO;
 import org.myrobotlab.logging.Level;
 import org.myrobotlab.logging.LoggerFactory;
 import org.myrobotlab.logging.LoggingFactory;
+import org.myrobotlab.service.config.ServiceConfig;
 import org.slf4j.Logger;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
@@ -603,23 +608,6 @@ public class CodecUtils {
     return ret;
   }
 
-  public static void main(String[] args) {
-    LoggingFactory.init(Level.INFO);
-
-    try {
-      String json = CodecUtils.fromJson("test", String.class);
-      log.info("json {}", json);
-      json = CodecUtils.fromJson("a test", String.class);
-      log.info("json {}", json);
-      json = CodecUtils.fromJson("\"a/test\"", String.class);
-      log.info("json {}", json);
-      CodecUtils.fromJson("a/test", String.class);
-
-    } catch (Exception e) {
-      log.error("main threw", e);
-    }
-  }
-
   /**
    * Creates a properly double encoded Json msg string. Why double encode ? -
    * because initial decode should decode router and header information. The
@@ -752,6 +740,32 @@ public class CodecUtils {
       return true;
     }
     return false;
+  }
+  
+  public static ServiceConfig readServiceConfig(String filename) throws IOException {
+    String data = new String(Files.readAllBytes(Paths.get(filename)), StandardCharsets.UTF_8);
+    Yaml yaml = new Yaml();
+    return (ServiceConfig)yaml.load(data);
+  }
+
+  public static void main(String[] args) {
+    LoggingFactory.init(Level.INFO);
+
+    try {
+      
+      Object o = readServiceConfig("data/config/InMoov2_FingerStarter/i01.chatBot.yml");
+      
+      String json = CodecUtils.fromJson("test", String.class);
+      log.info("json {}", json);
+      json = CodecUtils.fromJson("a test", String.class);
+      log.info("json {}", json);
+      json = CodecUtils.fromJson("\"a/test\"", String.class);
+      log.info("json {}", json);
+      CodecUtils.fromJson("a/test", String.class);
+
+    } catch (Exception e) {
+      log.error("main threw", e);
+    }
   }
 
 }

--- a/src/main/java/org/myrobotlab/service/ProgramAB.java
+++ b/src/main/java/org/myrobotlab/service/ProgramAB.java
@@ -961,9 +961,6 @@ public class ProgramAB extends Service implements TextListener, TextPublisher, L
   @Override
   public void startService() {
     super.startService();
-    if (peerSearch) {
-      startPeer("search");
-    }
 
     logPublisher = new SimpleLogPublisher(this);
     logPublisher.filterClasses(new String[] { "org.alicebot.ab.Graphmaster", "org.alicebot.ab.MagicBooleans", "class org.myrobotlab.programab.MrlSraixHandler" });
@@ -1135,7 +1132,7 @@ public class ProgramAB extends Service implements TextListener, TextPublisher, L
     }
 
     // TODO: attach to the text publishers... ?
-    
+
     return config;
   }
 

--- a/src/main/java/org/myrobotlab/service/config/InMoov2Config.java
+++ b/src/main/java/org/myrobotlab/service/config/InMoov2Config.java
@@ -1,18 +1,423 @@
 package org.myrobotlab.service.config;
 
 public class InMoov2Config extends ServiceConfig {
+  
+      // ;----------------------------- BASIC CONFIGURATION ----------------------------------------
+      // [MAIN]
+      public String ScriptType="Virtual";
+      // RightSide: Also called FINGERSTARTER : connect one arduino ( called right ) to use FingerStarter + inmoov right side
+      // LeftSide: connect one arduino ( called left) to use head / inmoov left side
+      // setup your com ports inside service_6_Arduino.config
+      // NoArduino: vocal Only
+      // Full: Both side arduinos connected
+      // Virtual: virtual arduino and inmoov !
+      public boolean debug=false;
 
+      String Language="en-US";
+      // ; en-US,fr-FR,es-ES,de-DE,nl-NL,ru-RU,hi-IN,it-IT,fi-FI,pt-PT,tr-TR
+
+      // ;----------------------------------- END --------------------------------------------------
+
+      // ;----------------------------- ADVANCED & OPTIONAL CONFIGURATION -------------------------------------
+
+      // [VOCAL]
+      public boolean IsMute=false;
+      // ;if true; : robot don't talk about starting actions
+
+      // [GENERAL]
+      public boolean LoadingPicture=false;
+      public boolean StartupSound=true;
+      // IuseLinux=false;
+      // ;some things dont work on mac and linux like marytts voice automatic download
+      public boolean LaunchSwingGui = false;
+      // ;usefull to speedup the system sometime
+      // betaversion = false;
+      // ;develop branch updates
+      // ;----------------------------------- END --------------------------------------------------
+
+  
+      ////////////////////////////////// InMoovLife.config.default //////////////////////////////////       
+      // ;----------------------------- INMOOV LIFE CONFIGURATION ----------------------------------------
+
+      // ;wip health check
+      // [HEALTHCHECK]
+      public boolean Activated=true;
+      public int TimerValue=60000;
+      public boolean BatteryInSystem=false;
+
+      // ;ramdom move the head
+      // [MOVEHEADRANDOM]
+      public boolean RobotCanMoveHeadWhileSpeaking=true;
+
+
+      // [SLEEPMODE]
+      public boolean ActivatedSleep=true;
+      public boolean UsePirToWakeUp=true;
+      public boolean UsePirToActivateTracking=false;
+
+      // ;Sleep 5 minutes after last presence detected
+      public int SleepTimeout=300000;
+
+      // ;Turn off tracking 20 seconds after last presence detected
+      public int TrackingTimeout=10000;
+
+      //////////////////// service_1_AudioFile.config.default ////////////////////////////
+      // ;----------------------------- AUDIO CONFIGURATION ----------------------------------------
+      // [AUDIO]
+
+      public String MyMusicPath="C:\\User\\XXX\\Music\\";
+      // ; Define the path for your music directory, this will be used when playing music by the robot
+      // ;------------------------------------- END ------------------------------------------------
+      
+     
+      //////////////////// service_4_Ear.config.default ////////////////////////////
+      // ;----------------------------- EAR CONFIGURATION ----------------------------------------
+      // [MAIN]
+      public String EarEngine="WebkitSpeechRecognition";
+      // ;WebkitSpeechRecognition,AndroidSpeechRecognition,Sphinx
+      public int setContinuous=0;
+      // ;setContinuous=0/1 0 is immediate processing
+      public int setAutoListen=1;
+      // ;auto rearm microphone
+      public int ForceMicroOnIfSleeping=1;
+      // MagicCommandToWakeUp=wake up ; user AbstractSpeechRecognition "wakeWord"
+      // USE wakeWord
+      // ;sleep tweaks
+      // ;----------------------------------- END --------------------------------------------------
+
+
+      //////////////////// service_5_Mouth.config.default ////////////////////////////
+    
+      // [TTS]
+
+      public String Speechengine="MarySpeech";
+
+          // ; you can use : 
+          // ;MarySpeech : open source TTS : http://myrobotlab.org/service/MarySpeech
+          // ;LocalSpeech : Local operating system TTS : http://myrobotlab.org/service/LocalSpeech
+          // ;Polly : [NEED API KEY AccessKey (apiKey1) and SecretKey (apiKey2)] http://myrobotlab.org/service/Polly
+          // ;VoiceRss : [NEED API KEY (apiKey1)] Free cloud service : http://myrobotlab.org/service/VoiceRss
+          // ;IndianTts : [NEED API KEY (apiKey1) and userid (apiKey2)] Hindi support : http://myrobotlab.org/service/IndianTts
+
+          public String VoiceName="Mark";
+
+          // ; MarySpeech voices -  http://myrobotlab.org/service/MarySpeech ( Mark, etc... ) print mouth.getVoices()
+          // ; LocalSpeech : use local windows voices/macOs ( Ziza, etc... ) print mouth.getVoices()
+          // ; amazon polly :  http://docs.aws.amazon.com/polly/latest/dg/voicelist.html
+
+          // [API_KEY]
+          // apiKey1=
+          // apiKey2=
+
+          //////////////////// service_6_Arduino.config.default ////////////////////////////
+
+          // ;----------------------------- ARDUINOS CONFIG ----------------------------------------
+          // [MAIN]
+
+          // ;my rightport if used ( /dev/ttyUSB0 for linux/macos )
+          public String MyRightPort="COM4";
+          public String BoardTypeMyRightPort="atmega2560";
+          public String ArefRightArduino="DEFAULT";
+
+          // ;my leftport if used
+          public String MyLeftPort="COM3";
+          public String BoardTypeMyLeftPort="atmega2560";
+          public String ArefLeftArduino="DEFAULT";
+
+          public boolean ForceArduinoIsConnected=false;
+          // ; BoardType Info
+          // ; atmega2560 | atmega168 | atmega328 | atmega328p | atmega1280 | atmega32u4
+
+          // ;----------------------------------- END --------------------------------------------------
+
+
+          //////////////////// service_8_NervoBoardRelay.config.default ////////////////////////////
+
+          // ;----------------------------- NERVO BOARD RELAY ----------------------------------------
+          // [MAIN]
+          public boolean isNervoboardRelayActivated=false;
+
+          // ;witch arduino control relay :
+          public String NervoboardRelayControlerArduino="left";
+          public int PinLeftNervoPower1=51;
+          public int PinRightNervoPower1=53;
+
+          // ;----------------------------------- END --------------------------------------------------
+
+          //////////////////// service_9_neoPixel.config.default ////////////////////////////
+
+          // ;----------------------------- NEOPIXEL RX/TX CONFIG ----------------------------------------
+          // [MAIN]
+          public boolean isNeopixelActivated=false;
+          public String NeopixelMaster="left";
+          // ;NeopixelMaster= right / left
+          public String NeopixelMasterPort="Serial2";
+          // ;NeopixelMasterPort= COMx for usb / Serialx for rx-tx ( Serial is case sensitive )
+          // [NEOPIXEL]
+          public int pin=2;
+          public int numberOfPixel=16;
+
+          // ;Background neopixel reactions
+          // [BASIC_REACTIONS]
+          public boolean boot_green=true;
+          public boolean downloadSomething_blue=true;
+          public boolean error_red=true;
+          public boolean flash_when_speak = true;
+          // ;----------------------------------- END --------------------------------------------------
+
+          //////////////////// service_A_Chatbot.config.default ////////////////////////////
+          // ;----------------------------- CHATBOT CONFIG ----------------------------------------
+          // [MAIN]
+          public boolean isChatBotActivated=true;
+          // ;----------------------------------- END --------------------------------------------------
+
+          //////////////////// service_C_Pir.config.default ////////////////////////////
+          // ;----------------------------- PIR CONFIGURATION ----------------------------------------
+          // [MAIN]
+          public boolean isPirActivated=false;
+
+          // ;witch arduino control pir :
+          public String pirControlerArduino="right";
+          public int pirPin=23;
+          public boolean PlayCurstomSoundIfDetection=true;
+
+          // ;----------------------------------- END --------------------------------------------------
+
+          //////////////////// service_D_OpenCv.config.default ////////////////////////////
+          // ;----------------------------- OPENCV CONFIGURATION ----------------------------------------
+          // [MAIN]
+          public boolean isOpenCvActivated=true;
+          // ;Activate OpenCv service...
+          public boolean faceRecognizerActivated=true;
+          // ;Activate faceRecognizer filter if tracking activated ...
+
+          public int CameraIndex=0;
+          public String DisplayRender="OpenCV";
+          // ;Available DisplayRender :
+          // ;Sarxos
+          // ;VideoInput
+          // ;OpenCV
+
+          public boolean streamerEnabled=false;
+
+          // ;----------------------------------- END --------------------------------------------------
+          //////////////////// service_D_OpenCv.config.default ////////////////////////////
+          // ;----------------------------- KINECT CONFIGURATION ----------------------------------------
+          // [MAIN]
+          public boolean isKinectActivated=false;
+          public int openNiShouldersOffset=-50;
+          public boolean openNiLeftShoulderInverted=true;
+          public boolean openNiRightShoulderInverted=true;
+
+          // ;----------------------------------- END --------------------------------------------------
+
+
+          //////////////////// service_D_OpenCv.config.default ////////////////////////////
+          // ;----------------------------- VIRTUAL INMOOV CONFIGURATION ----------------------------------------
+          // [MAIN]
+          public boolean isSimulatorActivated=true;
+          // ;use real arduino + virtual inmoov
+          public boolean VinmoovMonitorActivated=false;
+          // ;some kind of control center, unfinished
+          public boolean ForceVinmoovDisable=false;
+          // ;never launch JME3/Virtual Inmoov
+          // ;----------------------------------- END --------------------------------------------------
+
+          //////////////////// service_G_Translator.config.default ////////////////////////////
+          // ;----------------------------- TRANSLATOR CONFIGURATION ----------------------------------------
+          // [MAIN]
+          public String outputSpeechService="default";
+          // ;default=you can use your daily speech service for translated things
+          // ;if your speech service is languages limited, you can use an other for translated things only :
+          // ;( MarySpeech, Polly, NaturalReaderSpeech )
+
+          public boolean UseMaleVoice=false;
+          // apikey=
+          // ;Get your Microsoft KEY : https://github.com/MyRobotLab/inmoov/wiki/TRANSLATOR-SERVICE
+          // ;----------------------------------- END --------------------------------------------------
+
+          //////////////////// service_H_OpenWeatherMap.config.default ////////////////////////////
+          // ;----------------------------- OPENWEATHERMAP CONFIGURATION ----------------------------------------
+          // [MAIN]
+          public String setUnits="metric";
+          // ;or imperial
+          // apikey=
+          public String town="paris,FR";
+          // ;Get your KEY : https://home.openweathermap.org
+          // ;----------------------------------- END --------------------------------------------------
+
+          //////////////////// service_I_UltraSonicSensor.config.default ////////////////////////////
+          // ;----------------------------- ultra Sonic Sensor CONFIGURATION ----------------------------------------
+          // [MAIN]
+          public boolean ultraSonicRightActivated=false;
+          public String ultraSonicRightArduino="right";
+          public int trigRightPin=64;
+          public int echoRightPin=63;
+
+          public boolean ultraSonicLeftActivated=false;
+          public String ultraSonicLeftArduino="left";
+          public int trigLeftPin=64;
+          public int echoLeftPin=63;
+          // ;--------------------------------END-------------------------------------------
+
+          
+          //////////////////////////// service_J_SensorFinger.config //////////////////////////////////
+          
+       // ;----------------------------- finger Sensor CONFIGURATION ----------------------------------------;
+       // [MAIN]
+        
+       public boolean rightHandSensorActivated=false;
+       public String rightHandSensorArduino="right";
+
+       public int right_thumb_Psi_min=544  ;// Put here the max value when the sensor is NOT pressed
+       public int right_thumb_Psi_low=545  ;// In average cases take the min value and add +1 if using a AH3503 Hall Sensor
+       public int right_thumb_Psi_mid=547  ;// In average cases take the min value and add +4
+       public int right_thumb_Psi_max=550  ;// In average cases take the min value and add +7
+
+       public int right_index_Psi_min=538;
+       public int right_index_Psi_low=539;
+       public int right_index_Psi_mid=542;
+       public int right_index_Psi_max=545;
+
+       public int right_majeure_Psi_min=544;
+       public int right_majeure_Psi_low=545;
+       public int right_majeure_Psi_mid=547;
+       public int right_majeure_Psi_max=550;
+
+       public int right_ringFinger_Psi_min=544;
+       public int right_ringFinger_Psi_low=545;
+       public int right_ringFinger_Psi_mid=547;
+       public int right_ringFinger_Psi_max=550;
+
+       public int right_pinky_Psi_min=544;
+       public int right_pinky_Psi_low=545;
+       public int right_pinky_Psi_mid=547;
+       public int right_pinky_Psi_max=550;
+
+       public int right_extra_Psi_min=544;
+       public int right_extra_Psi_low=545;
+       public int right_extra_Psi_mid=547;
+       public int right_extra_Psi_max=550;
+
+
+       // ;analog pin range are 14-18 on uno, 54-70 on mega;
+       public int right_thumbPin=54 ;//--------A0;
+       public int right_indexPin=55 ;//--------A1;
+       public int right_majeurePin=56 ;//------A2;
+       public int right_ringFingerPin=57 ;//---A3;
+       public int right_pinkyPin=58 ;//--------A4;
+       public int right_extraPin=62 ;//--------A5;
+
+
+       public boolean leftHandSensorActivated=false;
+       public String leftHandSensorArduino="left";
+
+       public int left_thumb_Psi_min=544;
+       public int left_thumb_Psi_low=545;
+       public int left_thumb_Psi_mid=547;
+       public int left_thumb_Psi_max=550;
+
+       public int left_index_Psi_min=544;
+       public int left_index_Psi_low=545;
+       public int left_index_Psi_mid=547;
+       public int left_index_Psi_max=550;
+
+       public int left_majeure_Psi_min=544;
+       public int left_majeure_Psi_low=545;
+       public int left_majeure_Psi_mid=547;
+       public int left_majeure_Psi_max=550;
+
+       public int left_ringFinger_Psi_min=544;
+       public int left_ringFinger_Psi_low=545;
+       public int left_ringFinger_Psi_mid=547;
+       public int left_ringFinger_Psi_max=550;
+
+       public int left_pinky_Psi_min=544;
+       public int left_pinky_Psi_low=545;
+       public int left_pinky_Psi_mid=547;
+       public int left_pinky_Psi_max=550;
+
+       public int left_extra_Psi_min=544;
+       public int left_extra_Psi_low=545;
+       public int left_extra_Psi_mid=547;
+       public int left_extra_Psi_max=550;
+
+       // ;analog pin range are 14-18 on uno, 54-70 on mega;
+       public int left_thumbPin=54 ;//--------A0;
+       public int left_indexPin=55 ;//--------A1;
+       public int left_majeurePin=56 ;//------A2;
+       public int left_ringFingerPin=57 ;//---A3;
+       public int left_pinkyPin=58 ;//--------A4;
+       public int left_extraPin=62 ;//--------A5;
+          
+       /////////////////////////////////// skeleton_eyeLids.config  ////////////////////////////
+          
+       // ;----------------------------- EYELID CONFIGURATION ----------------------------------------
+       // [MAIN]
+       public boolean isEyeLidsActivated=false;
+       public String EyeLidsConnectedToArduino="right";
+       // ;chose left or right existing and connected arduino
+
+       public boolean EyeLidsLeftActivated=false;
+           public boolean EyeLidsRightActivated=false;
+       // ;EyeLidsLeftActivated : 1 servo control 2 eyelids
+       // ;EyeLidsRightActivated+EyeLidsLeftActivated : 1 servo control 1 eyelid
+
+
+       // [SERVO_MINIMUM_MAP_OUTPUT]
+       // ;your servo minimal limits
+       public int eyelidLeft=60;
+       public int eyelidRight=60;
+
+       // [SERVO_MAXIMUM_MAP_OUTPUT]
+       // ;your servo maximal limits
+       public int eyelidLeftMap=120;
+       public int eyelidRightMap=120;
+
+       // [SERVO_REST_POSITION]
+       public int eyelidLeftRest=0;
+       public int eyelidRightRest=0;
+
+
+       // ;----------------------------------- ADVANCED CONFIGURATION --------------------------------------------------
+
+       // [SERVO_INVERTED]
+           public boolean eyelidLeftInverted=false;
+          public boolean eyelidRightInverted=false;
+
+       // [MAX_SPEED]
+       public int eyelidLeftSpeed=100;
+       public int eyelidRightSpeed=100;
+
+       //[MINIMUM_MAP_INPUT]
+           public int eyelidLeftInput=0;
+               public int eyelidRightInput=0;
+
+       // [MAXIMUM_MAP_INPUT]
+           // public int eyelidLeftMap=180;
+           //public int eyelidRightMap=180;
+
+       // [SERVO_PIN]
+           public int eyelidLeftPin=22;
+               public int eyelidRightPin=24;
+
+       // [SERVO_AUTO_DISABLE]
+       public boolean eyelidLeftDisable=true;
+           public boolean eyelidRightDisable=true;
+
+       // ;----------------------------------- END --------------------------------------------------
+
+
+
+       
   public boolean isController3Activated = false;
   public boolean isController4Activated = false;
-  public boolean isEyeLidsActivated = false;
   public boolean isHeadActivated = true;
   public boolean isLeftArmActivated = false;
   public boolean isLeftHandActivated = false;
   public boolean isLeftHandSensorActivated = false;
   public boolean isLeftPortActivated = false;;
-  public boolean isNeopixelActivated = false;
   public boolean isOpenCVActivated = false;
-  public boolean isPirActivated = false;
   public boolean isRightArmActivated = false;
   public boolean isRightHandActivated = false;
   public boolean isRightHandSensorActivated = false;
@@ -21,11 +426,21 @@ public class InMoov2Config extends ServiceConfig {
   public boolean isTorsoActivated = false;
   public boolean isUltraSonicLeftActivated = false;
   public boolean isUltraSonicRightActivated = false;
-  
-  public boolean isSimulatorActivated = false;
-  
+
   public boolean loadGestures = false;
-  
+
+
+
+  /**
+   * Wake word functionality is activated when it is set (ie not null) This
+   * means recognizing events will be processed "after" it hears the wake word.
+   * It will continue to publish events until a idle timeout period is reached.
+   * It can continue to listen after this, but it will not publish. It fact, it
+   * 'must' keep listening since in this idle state it needs to search for the
+   * wake word
+   */
+  public String wakeWord;
+
   public boolean RobotCanMoveBodyRandom;
   public boolean RobotCanMoveEyesRandom;
   public boolean RobotCanMoveHeadRandom;

--- a/src/main/java/org/myrobotlab/service/config/InMoov2Config.java
+++ b/src/main/java/org/myrobotlab/service/config/InMoov2Config.java
@@ -2,33 +2,35 @@ package org.myrobotlab.service.config;
 
 public class InMoov2Config extends ServiceConfig {
 
+  public boolean isController3Activated = false;
+  public boolean isController4Activated = false;
+  public boolean isEyeLidsActivated = false;
+  public boolean isHeadActivated = true;
+  public boolean isLeftArmActivated = false;
+  public boolean isLeftHandActivated = false;
+  public boolean isLeftHandSensorActivated = false;
+  public boolean isLeftPortActivated = false;;
+  public boolean isNeopixelActivated = false;
+  public boolean isOpenCVActivated = false;
+  public boolean isPirActivated = false;
+  public boolean isRightArmActivated = false;
+  public boolean isRightHandActivated = false;
+  public boolean isRightHandSensorActivated = false;
+  public boolean isRightPortActivated = false;
+  public boolean isServoMixerActivated = false;
+  public boolean isTorsoActivated = false;
+  public boolean isUltraSonicLeftActivated = false;
+  public boolean isUltraSonicRightActivated = false;
+  
+  public boolean isSimulatorActivated = false;
+  
+  public boolean loadGestures = false;
+  
   public boolean RobotCanMoveBodyRandom;
-  public boolean RobotCanMoveHeadRandom;
   public boolean RobotCanMoveEyesRandom;
+  public boolean RobotCanMoveHeadRandom;
   public boolean RobotCanMoveRandom;
   public boolean RobotIsSleeping;
   public boolean RobotIsStarted;
-
-  public boolean loadGestures = true;
-
-  public boolean isRightHandActivated = true;;
-  public boolean isLeftHandActivated = true;
-  public boolean isRightArmActivated = true;
-  public boolean isLeftArmActivated = true;
-  public boolean isHeadActivated = true;
-  public boolean isTorsoActivated = true;
-  public boolean isEyeLidsActivated = true;
-  public boolean isServoMixerActivated = true;
-  public boolean isPirActivated = false;
-  public boolean isUltraSonicRightActivated = false;
-  public boolean isUltraSonicLeftActivated = false;
-  public boolean isNeopixelActivated = false;
-  public boolean isOpenCVActivated = false;
-  public boolean isRightHandSensorActivated = false;
-  public boolean isLeftHandSensorActivated = false;
-  public boolean isRightPortActivated = true;
-  public boolean isLeftPortActivated = true;
-  public boolean isController3Activated = false;
-  public boolean isController4Activated = false;
 
 }

--- a/src/test/java/ArduinoServoConfigTest.java
+++ b/src/test/java/ArduinoServoConfigTest.java
@@ -59,8 +59,8 @@ public class ArduinoServoConfigTest {
     // Runtime.createAndStart("webgui", "WebGui");
     // Runtime.createAndStart("gui", "SwingGui");
     // load it up.
-    // Runtime.getInstance().setConfigName("simple");
-    Runtime.getInstance().load("data/config/simple/runtime.yml");
+    Runtime.setConfig("simple");
+    Runtime.getInstance().load(); // "data/config/simple/runtime.yml"
     System.out.println("Loaded...");
 
     Runtime.createAndStart("gui", "SwingGui");
@@ -99,7 +99,7 @@ public class ArduinoServoConfigTest {
     Runtime.createAndStart("webgui", "WebGui");
     Runtime.createAndStart("gui", "SwingGui");
     // load it up.
-    Runtime.getInstance().load("data/config/runtime.yml");
+    Runtime.getInstance().load(); // "data/config/runtime.yml"
     System.out.println("Loaded...");
 
     waitOnAnyKey();

--- a/src/test/java/org/myrobotlab/service/ServiceInterfaceTest.java
+++ b/src/test/java/org/myrobotlab/service/ServiceInterfaceTest.java
@@ -97,6 +97,7 @@ public class ServiceInterfaceTest extends AbstractTest {
 
     HashSet<String> blacklist = new HashSet<String>();
     blacklist.add("OpenNi");
+    blacklist.add("IntegratedMovement");    
     blacklist.add("VirtualDevice");
     blacklist.add("GoogleAssistant");
     blacklist.add("LeapMotion");


### PR DESCRIPTION
Created 3 new Runtime methods
* Runtime.create(name)
* Runtime.load(name)
* Runtime.start(name)

These methods require appropriate config to be in data/config/{config set name}/{name}.yml
Because the type information is in the file - you can now with these methods easily change service type based on config.
This goes for peers as well, and with the use case of peers its probably more appropriate to configure overrides.

Also updated the existing Runtime.start (name, type) to go through lifecycle of load - however, since type is explicitly set here - config is not required to start a service without configuration.  If configuration is available, it will be used.  If incorrect type is in configuration which doesn't match Runtime.start(name, {type}) and error will be logged, but the service will start with without configuration of the type originally specified.