### PR TITLE
Clean Release - fixed Runtime and Polly release

### DIFF
--- a/src/main/java/org/myrobotlab/service/Polly.java
+++ b/src/main/java/org/myrobotlab/service/Polly.java
@@ -349,6 +349,13 @@ public class Polly extends AbstractSpeechSynthesis {
     }
 
   }
+  
+  public void releaseService() {
+    super.stopService();
+    if (polly != null) {
+      polly.shutdown();
+    }
+  }
 
   @Override
   public boolean isReady() {

--- a/src/main/java/org/myrobotlab/service/Runtime.java
+++ b/src/main/java/org/myrobotlab/service/Runtime.java
@@ -570,7 +570,10 @@ public class Runtime extends Service implements MessageListener, ServiceLifeCycl
           runtime.startingServices.add("python");
           
           try {
-            runtime.load();
+            if (options.config != null) {
+              runtime.setConfigName(options.config);
+              runtime.load();
+            }
           } catch(Exception e) {
             log.info("runtime will not be loading config");
           }

--- a/src/main/resources/resource/WebGui/app/service/js/RuntimeGui.js
+++ b/src/main/resources/resource/WebGui/app/service/js/RuntimeGui.js
@@ -283,9 +283,11 @@ angular.module('mrlapp.service.RuntimeGui', []).controller('RuntimeGuiCtrl', ['$
         console.info('releaseConfig')
         if ($scope.selectedConfig && $scope.selectedConfig.length) {
             for (let i = 0; i < $scope.selectedConfig.length; ++i) {
-                msg.sendTo('runtime', 'setConfigName', $scope.selectedConfig[i])
-                msg.sendTo('runtime', 'releaseConfig', 'runtime')
+                msg.sendTo('runtime', 'releaseConfig', $scope.selectedConfig[i])
+                // msg.sendTo('runtime', 'releaseConfig', 'runtime')
             }
+        } else {
+            msg.sendTo('runtime', 'releaseConfig')
         }
     }
 

--- a/src/test/java/org/myrobotlab/service/InProcessCliTest.java
+++ b/src/test/java/org/myrobotlab/service/InProcessCliTest.java
@@ -60,10 +60,12 @@ public class InProcessCliTest extends AbstractTest {
     clear();
     write("pwd");
     String ret = getResponse();
+    Thread.sleep(200);
     assertTrue(ret.startsWith("\"/\""));
 
     clear();
     write("ls");
+    Thread.sleep(200);
     assertTrue(getResponse().contains(toJson(Runtime.getServiceNames())));
 
     boolean virtual = runtime.isVirtual();
@@ -72,8 +74,10 @@ public class InProcessCliTest extends AbstractTest {
     clear();
     write("/runtime/setVirtual/false");
     ret = getResponse();
+    Thread.sleep(200);
     assertFalse(runtime.isVirtual());
     write("/runtime/setVirtual/true");
+    Thread.sleep(200);
     assertTrue(runtime.isVirtual());
     // replace with original value
     runtime.setVirtual(virtual);
@@ -82,6 +86,7 @@ public class InProcessCliTest extends AbstractTest {
     Clock clockCli = (Clock) Runtime.start("clockCli", "Clock");
     write("/clockCli/setInterval/1234");
     Integer check = 1234;
+    Thread.sleep(200);
     assertEquals(check, clockCli.getInterval());
 
   }


### PR DESCRIPTION
If you wanted to cleanly release all services - done by releasing config with runtime included
The InProcessCli would infinitely block on a read.  The thread (on Linux) can not be interrupted, and the System.in can not be closed.  So therefore, the thread would just hang on input.
It now avoids the infinite un-interruptable blocking read, by every 100ms checking for availability of input or shutting down.

Polly aws library has a thread that needs shutting down when released