### PR TITLE
bump jssc version to 2.9.4 to support mac m1 cpus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1328,7 +1328,7 @@
   <dependency>
     <groupId>io.github.java-native</groupId>
     <artifactId>jssc</artifactId>
-    <version>2.9.2</version>
+    <version>2.9.4</version>
     <scope>provided</scope>
   </dependency>
 <!-- Serial end -->

--- a/src/main/java/org/myrobotlab/service/meta/SerialMeta.java
+++ b/src/main/java/org/myrobotlab/service/meta/SerialMeta.java
@@ -16,7 +16,7 @@ public class SerialMeta extends MetaData {
 
     addDescription("reads and writes data to a serial port");
     addCategory("sensors", "control");
-    addDependency("io.github.java-native", "jssc", "2.9.2");
+    addDependency("io.github.java-native", "jssc", "2.9.4");
     setLicenseGplV3(); // via jssc
 
   }


### PR DESCRIPTION
jssc added support for mac M1 cpus in 2.9.3 ... this PR bumps our version to include that fix.  (with any luck.)