### PR TITLE
Add Maven Enforcer plugin and ban duplicate POM dependency rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1748,12 +1748,34 @@
             <artifactId>properties-maven-plugin</artifactId>
             <version>1.0.0</version>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>3.1.0</version>
+         </plugin>
         </plugins>
       </pluginManagement>
   
           <!-- use plugin -->
       <plugins>
-      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+            <execution>
+                <id>no-duplicate-declared-dependencies</id>
+                <goals>
+                    <goal>enforce</goal>
+                </goals>
+                <configuration>
+                    <rules>
+                        <banDuplicatePomDependencyVersions/>
+                    </rules>
+                </configuration>
+            </execution>
+        </executions>
+      </plugin>
+
       <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>properties-maven-plugin</artifactId>        

--- a/src/main/resources/resource/framework/pom.xml.template
+++ b/src/main/resources/resource/framework/pom.xml.template
@@ -144,12 +144,34 @@
             <artifactId>properties-maven-plugin</artifactId>
             <version>1.0.0</version>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>3.1.0</version>
+         </plugin>
         </plugins>
       </pluginManagement>
   
           <!-- use plugin -->
       <plugins>
-      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+            <execution>
+                <id>no-duplicate-declared-dependencies</id>
+                <goals>
+                    <goal>enforce</goal>
+                </goals>
+                <configuration>
+                    <rules>
+                        <banDuplicatePomDependencyVersions/>
+                    </rules>
+                </configuration>
+            </execution>
+        </executions>
+      </plugin>
+
       <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>properties-maven-plugin</artifactId>        


### PR DESCRIPTION
This PR adds a new plugin called [Maven Enforcer](https://maven.apache.org/enforcer/maven-enforcer-plugin/index.html) and adds a rule called [banDuplicatePOMDependencyVersions](https://maven.apache.org/enforcer/enforcer-rules/banDuplicatePomDependencyVersions.html). Together, they ensure we do not end up with duplicate dependencies in the POM as running `mvn validate` (and therefore `mvn verify`) would fail the build.