### PR TITLE
Bundle Python 3.11 for Py4j

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # TODO clean this up !
 /.project
 /.classpath
-/*.iml
 /.settings
 /src/main/resources/resource/WebGui/react
 /src/main/resources/resource/Vertx/app
@@ -83,3 +82,4 @@
 /lastRestart.py
 /.factorypath
 start.yml
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -1240,6 +1240,12 @@
     <version>3.11.3-1.5.9</version>
     <scope>provided</scope>
   </dependency>
+  <dependency>
+    <groupId>org.bytedeco</groupId>
+    <artifactId>cpython</artifactId>
+    <version>3.11.3-1.5.9</version>
+    <scope>provided</scope>
+  </dependency>
 <!-- Py4j end -->
 
 <!-- Python begin -->

--- a/pom.xml
+++ b/pom.xml
@@ -1234,6 +1234,12 @@
     <version>0.10.9.7</version>
     <scope>provided</scope>
   </dependency>
+  <dependency>
+    <groupId>org.bytedeco</groupId>
+    <artifactId>cpython-platform</artifactId>
+    <version>3.11.3-1.5.9</version>
+    <scope>provided</scope>
+  </dependency>
 <!-- Py4j end -->
 
 <!-- Python begin -->

--- a/src/main/java/org/myrobotlab/service/config/Py4jConfig.java
+++ b/src/main/java/org/myrobotlab/service/config/Py4jConfig.java
@@ -7,5 +7,11 @@ public class Py4jConfig extends ServiceConfig {
    *  /data/Py4j/{serviceName}
    */
   public String scriptRootDir;
+
+  /**
+   * Whether to use the bundled Python executable
+   * or invoke the system Python.
+   */
+  public boolean useBundledPython = true;
   
 }

--- a/src/main/java/org/myrobotlab/service/meta/Py4jMeta.java
+++ b/src/main/java/org/myrobotlab/service/meta/Py4jMeta.java
@@ -22,6 +22,7 @@ public class Py4jMeta extends MetaData {
     // Used just as a Python exe redistributable.
     // ABSOLUTELY NO JNI/JNA IS USED
     addDependency("org.bytedeco", "cpython-platform", "3.11.3-1.5.9");
+    addDependency("org.bytedeco", "cpython", "3.11.3-1.5.9");
   }
 
 }

--- a/src/main/java/org/myrobotlab/service/meta/Py4jMeta.java
+++ b/src/main/java/org/myrobotlab/service/meta/Py4jMeta.java
@@ -18,6 +18,10 @@ public class Py4jMeta extends MetaData {
     addCategory("programming");
     setSponsor("GroG");
     addDependency("net.sf.py4j", "py4j", "0.10.9.7");
+
+    // Used just as a Python exe redistributable.
+    // ABSOLUTELY NO JNI/JNA IS USED
+    addDependency("org.bytedeco", "cpython-platform", "3.11.3-1.5.9");
   }
 
 }

--- a/src/main/resources/resource/Py4j/Py4j.py
+++ b/src/main/resources/resource/Py4j/Py4j.py
@@ -5,7 +5,7 @@
 # Java objects in a Java Virtual Machine. 
 # Methods are called as if the Java objects resided in the Python interpreter and 
 # Java collections can be accessed through standard Python collection methods. 
-# Py4J also enables Java programs to call back Python objects. Py4J is distributed under the BSD
+# Py4J also enables Java programs to call back Python objects. Py4J is distributed under the BSD license
 # Python 2.7 -to- 3.x is supported
 # In your python 3.x project
 # pip install py4j
@@ -13,16 +13,20 @@
 # the gateway
 
 import sys
-from time import sleep
-from py4j.clientserver import ClientServer, JavaParameters, PythonParameters
-from py4j.java_collections import JavaList
 
+from py4j.java_collections import JavaObject, JavaClass
 from py4j.java_gateway import JavaGateway, CallbackServerParameters
-from py4j.java_collections import JavaArray, JavaObject, JavaClass
 
 runtime = None
 
+
 class MessageHandler(object):
+    """
+    The class responsible for receiving and processing Py4j messages,
+    including handling `invoke()` and `exec()` requests. Class
+    must be initialized and then the `setName()` method must be invoked before
+    the Java and Python sides can talk correctly.
+    """
 
     def __init__(self):
         global runtime
@@ -32,21 +36,27 @@ class MessageHandler(object):
         self.stderr = sys.stderr
         sys.stdout = self
         sys.stderr = self
-        self.gateway = JavaGateway(callback_server_parameters=CallbackServerParameters(), python_server_entry_point=self)
+        self.gateway = JavaGateway(callback_server_parameters=CallbackServerParameters(),
+                                   python_server_entry_point=self)
         self.runtime = self.gateway.jvm.org.myrobotlab.service.Runtime.getInstance()
         runtime = self.runtime
-        self.py4j = None # need to wait until name is set
+        self.py4j = None  # need to wait until name is set
 
-    def write(self,string):
-        if (self.py4j):
+    def write(self, string):
+        if self.py4j:
             self.py4j.handleStdOut(string)
 
-    def setName(self, name):
-        """Method called right after initialization from MRL
-        responsible for 'naming' the MessageHandler
+    def flush(self):
+        pass
 
-        Args:
-            name (string): sets the name of the MessageHandler
+    def setName(self, name):
+        """
+        Called after initialization completed in order
+        for this Python side handler to know how to contact the Java-side
+        service.
+
+        :param name: Name of the Java-side Py4j service this script is linked to, preferably as a full name.
+        :type name: str
         """
         self.name = name
         self.py4j = self.runtime.getService(name)
@@ -57,35 +67,52 @@ class MessageHandler(object):
         # TODO print env vars PYTHONPATH etc
         return name
 
-    def get_name(self):
-        return self.name
-    
     def exec(self, code):
-        """executes python script
+        """
+        Executes Python code in the global namespace.
+        All exceptions are caught and printed so that the Python subprocess doesn't crash.
 
-        Args:
-            code (_type_): code to execute
+        :param code: The Python code to execute.
+        :type code: str
         """
         try:
-            exec(code)
+            # Restricts the exec() to the global namespace,
+            # so the code is executed as if it were the top level of a module
+            exec(code, globals())
         except Exception as e:
             print(e)
 
-    def invoke(self, method, data=None):
+    def invoke(self, method, data=()):
+        """
+        Invoke a function from the global namespace with the given parameters.
+
+        :param method: The name of the function to invoke.
+        :type method: str
+        :param data: The parameters to pass to the function, defaulting to no parameters.
+        :type data: Iterable
+        """
+
         # convert to list
         params = list(data)
-        eval(method)(*params)
 
-    def flush(self):
-        pass
+        # Lookup the method in the global namespace
+        # Much much faster than using eval()
+        globals()[method](*params)
 
     def shutdown(self):
+        """
+        Shutdown the Py4j gateway
+        :return:
+        """
         self.gateway.shutdown()
-    
-    def getInstance(self):
-        return self.runtime
 
     def convert_array(self, array):
+        """
+        Utility method used by Py4j to convert arrays of Java objects
+        into equivalent Python lists.
+        :param array: The array to convert
+        :return: The converted array
+        """
         result = []
         for item in array:
             if isinstance(item, JavaObject):
@@ -115,5 +142,9 @@ class MessageHandler(object):
     class Java:
         implements = ['org.myrobotlab.framework.interfaces.Invoker']
 
+
 handler = MessageHandler()
-runtime = handler.getInstance()
+if len(sys.argv) > 1:
+    handler.setName(sys.argv[1])
+else:
+    raise RuntimeError("This script requires the full name of the Py4j service as its first command-line argument")

--- a/src/main/resources/resource/Py4j/py4j.yml
+++ b/src/main/resources/resource/Py4j/py4j.yml
@@ -2,4 +2,5 @@
 listeners: null
 peers: null
 scriptRootDir: null
+useBundledPython: true
 type: Py4j


### PR DESCRIPTION
This PR (ab)uses ByteDeco's CPython bindings library to bundle a Python executable as a normal dependency that Maven/Ivy manages. This PR *DOES NOT* use any JNI/JNA code whatsoever; the dependency is only an easy way for us to redistribute a Python executable so users no longer need to install one themselves.

Additionally, when using the aforementioned bundled Python, this PR creates a virtual environment in the service's data directory and installs Py4j into it. Thus, with this PR merged, using Py4j should be as easy and seamless as using the legacy Python service.

A config option is added to allow the usage of the system Python instead.