### PR TITLE
Fix non-transient package-private CvRect in SetImageROI filter

### DIFF
--- a/src/main/java/org/myrobotlab/opencv/OpenCVFilterSetImageROI.java
+++ b/src/main/java/org/myrobotlab/opencv/OpenCVFilterSetImageROI.java
@@ -38,7 +38,7 @@ import org.slf4j.Logger;
 public class OpenCVFilterSetImageROI extends OpenCVFilter {
 
   private static final long serialVersionUID = 1L;
-  CvRect rect = null;
+  private transient CvRect rect = null;
   public final static Logger log = LoggerFactory.getLogger(OpenCVFilterSetImageROI.class);
 
   public OpenCVFilterSetImageROI(String name) {


### PR DESCRIPTION
Fixes a bug where a non-transient CvRect field causes a stack overflow when serializing the SetImageROI filter