### PR TITLE
Add StaticType-based generic bounds for peer config utils

### DIFF
--- a/src/main/java/org/myrobotlab/framework/Service.java
+++ b/src/main/java/org/myrobotlab/framework/Service.java
@@ -1421,23 +1421,28 @@ public abstract class Service<T extends ServiceConfig> implements Runnable, Seri
    *          i01."opencv"
    * @return
    */
-  public ServiceConfig getPeerConfig(String peerKey) {
+  public <P extends ServiceConfig> P getPeerConfig(String peerKey, StaticType<P> type) {
     String peerName = getPeerName(peerKey);
     if (peerName == null) {
       error("peer name not found for peer key %s", peerKey);
       return null;
     }
 
-    ServiceInterface si = Runtime.getService(peerName);
+    // Java generics don't let us create a new StaticType using
+    // P here because the type variable is erased, so we have to cast anyway for now
+    ConfigurableService<P> si = (ConfigurableService<P>) Runtime.getService(peerName);
     if (si != null) {
       // peer is currently running - get its config
-      return si.getConfig();
+      P c = si.getConfig();
+      if (type.asClass().isAssignableFrom(c.getClass())) {
+        return c;
+      }
     }
 
     // peer is not currently running attempt to read from config
     Runtime runtime = Runtime.getInstance();
     // read current service config for this peer service
-    ServiceConfig sc = runtime.readServiceConfig(peerName);
+    P sc = runtime.readServiceConfig(peerName, type);
     if (sc == null) {
       error("peer service %s is defined, but %s.yml not available on filesystem", peerKey, peerName);
       return null;
@@ -1446,7 +1451,7 @@ public abstract class Service<T extends ServiceConfig> implements Runnable, Seri
   }
 
   public void setPeerConfigValue(String peerKey, String fieldname, Object value) throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
-    ServiceConfig sc = getPeerConfig(peerKey);
+    ServiceConfig sc = getPeerConfig(peerKey, new StaticType<>() {});
     if (sc == null) {
       error("invalid config for peer key %s field name %s", peerKey, fieldname);
       return;
@@ -1455,7 +1460,7 @@ public abstract class Service<T extends ServiceConfig> implements Runnable, Seri
     field.set(sc, value);
     savePeerConfig(peerKey, sc);
     String peerName = getPeerName(peerKey);
-    ConfigurableService cs = (ConfigurableService) Runtime.getService(peerName);
+    var cs = Runtime.getConfigurableService(peerName, new StaticType<Service<ServiceConfig>>() {});
     if (cs != null) {
       cs.apply(sc); // TODO - look for applies if its read from the file system
                     // it needs to update Runtime.plan
@@ -2845,6 +2850,10 @@ public abstract class Service<T extends ServiceConfig> implements Runnable, Seri
     apply((T) sc);
   }
 
+  public void applyPeerConfig(String peerKey, ServiceConfig config) {
+    applyPeerConfig(peerKey, config, new StaticType<>() {});
+  }
+
   /**
    * Apply the config to a peer, regardless if the peer is currently running or
    * not
@@ -2852,13 +2861,13 @@ public abstract class Service<T extends ServiceConfig> implements Runnable, Seri
    * @param peerKey
    * @param config
    */
-  public void applyPeerConfig(String peerKey, ServiceConfig config) {
+  public <P extends ServiceConfig> void applyPeerConfig(String peerKey, P config, StaticType<Service<P>> configServiceType) {
     String peerName = getPeerName(peerKey);
 
     Runtime.getPlan().put(peerName, config);
 
     // meh - templating is not very helpful here
-    ConfigurableService si = (ConfigurableService) Runtime.getService(peerName);
+    ConfigurableService<P> si = Runtime.getService(peerName, configServiceType);
     if (si != null) {
       si.apply(config);
     }

--- a/src/main/java/org/myrobotlab/framework/StaticType.java
+++ b/src/main/java/org/myrobotlab/framework/StaticType.java
@@ -81,6 +81,27 @@ public abstract class StaticType<T> {
         return storedType;
     }
 
+    /**
+     * Get the stored type as a Class object
+     * that can be used for checking cast
+     * compatibility. Note that the resulting
+     * Class object will not check for generic
+     * compatibility. If the stored type
+     * is not a Class type, then this method
+     * throws {@link IllegalStateException}.
+     *
+     * @return The internal stored type cast to a Class object
+     * @throws IllegalStateException if the stored type is not a Class.
+     */
+    @SuppressWarnings("unchecked")
+    public Class<T> asClass() {
+        if (storedType instanceof Class) {
+            return (Class<T>) storedType;
+        } else {
+            throw new IllegalStateException("Stored type " + storedType + " is not a Class.");
+        }
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -96,6 +117,11 @@ public abstract class StaticType<T> {
         return storedType != null ? storedType.hashCode() : 0;
     }
 
+
+    @Override
+    public String toString() {
+        return storedType.toString();
+    }
     /**
      * Function to recursively validate type parameters
      * to ensure they are all concrete so no type variables sneak in.

--- a/src/main/java/org/myrobotlab/service/InMoov2.java
+++ b/src/main/java/org/myrobotlab/service/InMoov2.java
@@ -16,6 +16,7 @@ import org.myrobotlab.framework.Plan;
 import org.myrobotlab.framework.Platform;
 import org.myrobotlab.framework.Registration;
 import org.myrobotlab.framework.Service;
+import org.myrobotlab.framework.StaticType;
 import org.myrobotlab.framework.Status;
 import org.myrobotlab.framework.interfaces.ServiceInterface;
 import org.myrobotlab.io.FileIO;
@@ -28,6 +29,7 @@ import org.myrobotlab.programab.Response;
 import org.myrobotlab.service.abstracts.AbstractSpeechRecognizer;
 import org.myrobotlab.service.abstracts.AbstractSpeechSynthesis;
 import org.myrobotlab.service.config.InMoov2Config;
+import org.myrobotlab.service.config.OpenCVConfig;
 import org.myrobotlab.service.config.ServiceConfig;
 import org.myrobotlab.service.data.JoystickData;
 import org.myrobotlab.service.data.LedDisplayData;
@@ -1939,6 +1941,8 @@ public class InMoov2 extends Service<InMoov2Config> implements ServiceLifeCycleL
       webgui.startService();
 
       InMoov2 i01 = (InMoov2)Runtime.start("i01","InMoov2");
+      OpenCVConfig ocvConfig = i01.getPeerConfig("opencv", new StaticType<>() {});
+      ocvConfig.flip = true;
       i01.setPeerConfigValue("opencv", "flip", true);
       // i01.savePeerConfig("", null);
       

--- a/src/test/java/org/myrobotlab/service/InMoov2Test.java
+++ b/src/test/java/org/myrobotlab/service/InMoov2Test.java
@@ -3,6 +3,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import org.myrobotlab.framework.StaticType;
 import org.myrobotlab.service.config.OpenCVConfig;
 
 public class InMoov2Test {
@@ -14,11 +15,11 @@ public class InMoov2Test {
       
       // flip
       i01.setPeerConfigValue("opencv", "flip", true);
-      OpenCVConfig cvconfig = (OpenCVConfig)i01.getPeerConfig("opencv");
+      OpenCVConfig cvconfig = i01.getPeerConfig("opencv", new StaticType<>() {});
       assertTrue(cvconfig.flip);
 
       i01.setPeerConfigValue("opencv", "flip", false);
-      cvconfig = (OpenCVConfig)i01.getPeerConfig("opencv");
+      cvconfig = i01.getPeerConfig("opencv", new StaticType<>() {});
       assertFalse(cvconfig.flip);
       
   }


### PR DESCRIPTION
Adds generic type bounds to peer config utils, which allows us to do type checking on the config classes and cleans up code that wants to modify peer configs.