### PR TITLE
Extract files only within the destination directory

### DIFF
--- a/src/main/java/org/myrobotlab/io/Zip.java
+++ b/src/main/java/org/myrobotlab/io/Zip.java
@@ -229,12 +229,23 @@ public class Zip {
     new File(newPath).mkdir();
     Enumeration<?> zipFileEntries = zip.entries();
 
+    File canonicalNewPath = new File(newPath).getCanonicalFile();
+
     // Process each entry
     while (zipFileEntries.hasMoreElements()) {
       // grab a zip file entry
       ZipEntry entry = (ZipEntry) zipFileEntries.nextElement();
       String currentEntry = entry.getName();
       File destFile = new File(newPath, currentEntry);
+        
+      // Canonicalize the destination file path
+      File canonicalDestFile = destFile.getCanonicalFile();
+
+      // Check if the canonical destination path starts with the canonical newPath
+      if (!canonicalDestFile.getPath().startsWith(canonicalNewPath.getPath())) {
+        throw new IOException("Attempt to write outside of the target directory: " + currentEntry);
+      }
+
       // destFile = new File(newPath, destFile.getName());
       File destinationParent = destFile.getParentFile();
 


### PR DESCRIPTION
Make sure files only get extracted within the specified destination to avoid the Zip Slip vulnerability. Without this patch the ZIP archive can contain relative paths and extract files to arbitrary paths the user has write permissions for.